### PR TITLE
Support Local Benchmarking on Vast.ai Instance

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -59,6 +59,25 @@ You can use the Orchestrator for an automated flow, but note that it currently r
   ```
   *Note: You will need to manually start the LLM server on the instance when the script prompts you.*
 
+### Option C: Local Benchmarking (Run on the Vast.ai instance)
+For the most accurate hardware metrics, you can run the benchmarking tools directly on the rented instance. This eliminates network latency between your local machine and the instance.
+
+- [ ] **SSH into the instance:** Use the credentials provided when renting.
+- [ ] **Setup Environment:**
+  ```bash
+  git clone <repo-url>
+  cd avast-ai-tests
+  pip install -r requirements.txt
+  ```
+- [ ] **Start LLM Engine:** (In a separate terminal or background)
+  ```bash
+  docker run --gpus all -p 8000:8000 vllm/vllm-openai --model google/gemma-2-9b-it
+  ```
+- [ ] **Run Orchestrator with Local URL:**
+  ```bash
+  python3 orchestrator.py --gpu "RTX 4090" --model "gemma-2-9b-it" --url http://localhost:8000 --run
+  ```
+
 ## Phase 5: Analyze Results
 - [ ] **Check Output File:** Results are saved as `benchmark_<gpu>_<timestamp>.json`.
 - [ ] **Verify Metrics:**

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -9,40 +9,46 @@ class Orchestrator:
     def __init__(self, api_key=None):
         self.vast = VastManager(api_key=api_key)
 
-    async def run_suite(self, gpu_name, model_name, concurrency_levels=[1, 4, 16], requests_per_level=10):
+    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10):
         print(f"Starting benchmark suite for {model_name} on {gpu_name}")
 
-        # 1. Find and rent instance
-        offers = self.vast.find_offers(gpu_name)
-        if not offers:
-            print(f"No offers found for {gpu_name}")
-            return
-
-        # Select the best offer (lowest price per hour)
-        offer_id = offers[0]['id']
-        instance_id = self.vast.rent_instance(offer_id)
-        if not instance_id:
-            return
-
-        try:
-            # 2. Wait for instance to be ready
-            instance = self.vast.wait_for_ssh(instance_id)
-            if not instance:
-                print("Instance failed to initialize")
+        instance_id = None
+        if url:
+            api_url = url
+            print(f"Using existing endpoint: {api_url}")
+        else:
+            # 1. Find and rent instance
+            offers = self.vast.find_offers(gpu_name)
+            if not offers:
+                print(f"No offers found for {gpu_name}")
                 return
 
-            print(f"Instance ready at {instance['ssh_host']}:{instance['ssh_port']}")
+            # Select the best offer (lowest price per hour)
+            offer_id = offers[0]['id']
+            instance_id = self.vast.rent_instance(offer_id)
+            if not instance_id:
+                return
 
-            # Implementation Note: In a production environment, this step would involve
-            # using an SSH library (like Paramiko) to run 'docker run' on the remote host.
-            # Example:
-            # ssh.exec_command("docker run -d --gpus all -p 8000:8000 vllm/vllm-openai --model gemma-7b")
+        try:
+            if not url:
+                # 2. Wait for instance to be ready
+                instance = self.vast.wait_for_ssh(instance_id)
+                if not instance:
+                    print("Instance failed to initialize")
+                    return
 
-            print("To complete the test, ensure the LLM engine is running on the remote host.")
-            print(f"URL: http://{instance['ssh_host']}:{instance['ssh_port']}")
+                print(f"Instance ready at {instance['ssh_host']}:{instance['ssh_port']}")
+                api_url = f"http://{instance['ssh_host']}:{instance['ssh_port']}"
+
+                # Implementation Note: In a production environment, this step would involve
+                # using an SSH library (like Paramiko) to run 'docker run' on the remote host.
+                # Example:
+                # ssh.exec_command("docker run -d --gpus all -p 8000:8000 vllm/vllm-openai --model gemma-7b")
+
+                print("To complete the test, ensure the LLM engine is running on the remote host.")
+                print(f"URL: {api_url}")
 
             # 3. Run benchmarks
-            api_url = f"http://{instance['ssh_host']}:{instance['ssh_port']}"
             tester = LoadTester(api_url, model_name)
 
             all_results = []
@@ -72,19 +78,21 @@ class Orchestrator:
 
         finally:
             # 5. Teardown
-            self.vast.destroy_instance(instance_id)
+            if instance_id:
+                self.vast.destroy_instance(instance_id)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Gemma Performance Lab Orchestrator")
     parser.add_argument("--gpu", type=str, default="RTX_4090", help="GPU model to test")
     parser.add_argument("--model", type=str, default="gemma-7b", help="Model name")
+    parser.add_argument("--url", type=str, help="Existing API endpoint URL (skips provisioning)")
     parser.add_argument("--run", action="store_true", help="Actually run the suite (requires Vast.ai credits)")
 
     args = parser.parse_args()
     orch = Orchestrator()
 
     if args.run:
-        asyncio.run(orch.run_suite(args.gpu, args.model))
+        asyncio.run(orch.run_suite(args.gpu, args.model, url=args.url))
     else:
         print("Orchestrator initialized.")
         print(f"Dry-run: Would test {args.model} on {args.gpu}")


### PR DESCRIPTION
This change enables users to run benchmarks directly on a Vast.ai instance, reducing network latency for more accurate hardware metrics. It introduces a `--url` flag to the orchestrator to skip instance provisioning and updates the documentation to reflect this new workflow.

Fixes #5

---
*PR created automatically by Jules for task [2509364909384335426](https://jules.google.com/task/2509364909384335426) started by @chatelao*