### PR TITLE
Support Vast.ai templates for faster vLLM setup

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -54,3 +54,14 @@ To avoid unnecessary charges, analyze your results and destroy the instance imme
 
 ## Phase 5: Fast Cleanup
 - [ ] **Destroy Instance:** Immediately go back to the [Vast.ai Console](https://vast.ai/console/instances/) and destroy the instance. For expensive hardware, every minute counts.
+
+## Pro Tip: Using Templates for Even Faster Setup
+Using a **Vast.ai Template** (configured via the Web Console) is significantly faster than manual `docker run` because:
+- **Instant Pull:** The host starts pulling the vLLM image the moment the instance is provisioned.
+- **Zero-Touch:** You can configure the `docker run` command and environment variables (like `HF_TOKEN`) directly in the template.
+- **Parallelism:** The engine starts while you are still SSHing in to clone the benchmarking repo.
+
+To use a template with our tools, find your template's **Hash ID** in the Vast.ai console and pass it to the orchestrator (if supported) or use it in `vast_manager.py`:
+```python
+mgr.rent_instance(offer_id, template_hash="your_template_hash")
+```

--- a/infra/vast_manager.py
+++ b/infra/vast_manager.py
@@ -12,9 +12,12 @@ class VastManager:
         offers = self.sdk.search_offers(query=query, order="dph_total")
         return offers
 
-    def rent_instance(self, offer_id, image="nvidia/cuda:12.1.1-devel-ubuntu22.04", disk=50):
-        print(f"Attempting to rent offer {offer_id} with image {image}...")
-        result = self.sdk.create_instance(id=offer_id, image=image, disk=disk)
+    def rent_instance(self, offer_id, image="nvidia/cuda:12.1.1-devel-ubuntu22.04", disk=50, template_hash=None):
+        if template_hash:
+            print(f"Attempting to rent offer {offer_id} using template {template_hash}...")
+        else:
+            print(f"Attempting to rent offer {offer_id} with image {image}...")
+        result = self.sdk.create_instance(id=offer_id, image=image, disk=disk, template_hash=template_hash)
         if result.get("success"):
             instance_id = result.get("new_contract")
             print(f"Successfully created instance {instance_id}")


### PR DESCRIPTION
This change introduces support for Vast.ai templates in the infrastructure management layer. By using a template hash during instance provisioning, the host can start pulling the vLLM Docker image and executing startup commands immediately, significantly reducing the "Time to Ready" compared to manual SSH-based setup. 

Key changes:
- `infra/vast_manager.py`: Added `template_hash` parameter to `rent_instance`.
- `HOWTO.md`: Added a "Pro Tip" section explaining the benefits and usage of templates.

Fixes #21

---
*PR created automatically by Jules for task [3935871311802198535](https://jules.google.com/task/3935871311802198535) started by @chatelao*