### PR TITLE
Add micro runtime test with smallest possible model

### DIFF
--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -68,35 +68,6 @@ jobs:
         # We do NOT install the 'vllm' package as it can conflict with 'vllm-cpu'
         pip install vllm-cpu --extra-index-url https://download.pytorch.org/whl/cpu
 
-    - name: Run vLLM server
+    - name: Run Micro Runtime Test (vLLM on CPU)
       run: |
-        # Use a very small model (facebook/opt-125m) and CPU mode
-        # dtype float is safer on CPU than half or auto
-        # Reduce max-model-len and block-size for lower memory consumption on CI
-        # Note: using the module entrypoint as the CLI might have metadata issues
-        python -m vllm.entrypoints.openai.api_server \
-          --model facebook/opt-125m \
-          --dtype float \
-          --enforce-eager \
-          --max-model-len 512 \
-          --block-size 16 \
-          --chat-template tests/dummy_chat_template.jinja > vllm.log 2>&1 &
-
-        # Wait for vLLM to be ready
-        # If vLLM fails to start (e.g. CPU instruction set mismatch), we'll catch it in the next step
-        timeout 300 bash -c 'until curl -sf http://localhost:8000/v1/models; do sleep 10; done' || (echo "vLLM failed to start within timeout" && exit 1)
-
-    - name: Run Orchestrator against vLLM
-      run: |
-        python orchestrator.py \
-          --url http://localhost:8000 \
-          --model facebook/opt-125m \
-          --gpu mock-cpu-gpu \
-          --concurrency-levels 1 2 \
-          --requests-per-level 5 \
-          --run || (echo "Benchmark failed, printing vLLM logs:" && cat vllm.log && exit 1)
-
-    - name: Check benchmark results
-      run: |
-        ls benchmark_mock-cpu-gpu_*.json
-        cat benchmark_mock-cpu-gpu_*.json | jq '.'
+        python tests/micro_runtime_test.py

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -52,5 +52,18 @@ To avoid unnecessary charges, analyze your results and destroy the instance imme
     - **ITL:** Inter-Token Latency (lower is better).
     - **TPS:** Tokens Per Second (higher is better).
 
+## Local Verification (Micro Runtime Test)
+If you want to verify the entire stack (Orchestrator + Load Tester + vLLM) without renting a GPU, you can run the micro runtime test on your local CPU. This uses a tiny 125M parameter model.
+
+- [ ] **Install vLLM-CPU:**
+  ```bash
+  pip install vllm-cpu --extra-index-url https://download.pytorch.org/whl/cpu
+  ```
+- [ ] **Run the Test:**
+  ```bash
+  python tests/micro_runtime_test.py
+  ```
+This script automates the server startup, benchmarking, and result verification.
+
 ## Phase 5: Fast Cleanup
 - [ ] **Destroy Instance:** Immediately go back to the [Vast.ai Console](https://vast.ai/console/instances/) and destroy the instance. For expensive hardware, every minute counts.

--- a/tests/micro_runtime_test.py
+++ b/tests/micro_runtime_test.py
@@ -1,0 +1,123 @@
+import subprocess
+import time
+import os
+import json
+import glob
+import sys
+import aiohttp
+import asyncio
+
+async def wait_for_server(url, timeout=300):
+    start_time = time.time()
+    async with aiohttp.ClientSession() as session:
+        while time.time() - start_time < timeout:
+            try:
+                async with session.get(f"{url}/v1/models") as response:
+                    if response.status == 200:
+                        print("Server is ready!")
+                        return True
+            except Exception:
+                pass
+            print("Waiting for server...")
+            await asyncio.sleep(10)
+    return False
+
+def run_test():
+    # Environment variables for CPU execution
+    env = os.environ.copy()
+    env["VLLM_TARGET_DEVICE"] = "cpu"
+    env["VLLM_DEVICE"] = "cpu"
+    env["VLLM_CPU_KVCACHE_SPACE"] = "1"
+    env["VLLM_NO_USAGE_STATS"] = "1"
+
+    vllm_process = None
+    try:
+        # Start vLLM server
+        print("Starting vLLM server with facebook/opt-125m on CPU...")
+        vllm_command = [
+            sys.executable, "-m", "vllm.entrypoints.openai.api_server",
+            "--model", "facebook/opt-125m",
+            "--dtype", "float",
+            "--enforce-eager",
+            "--max-model-len", "512",
+            "--block-size", "16",
+            "--chat-template", "tests/dummy_chat_template.jinja"
+        ]
+
+        vllm_process = subprocess.Popen(
+            vllm_command,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True
+        )
+
+        # Wait for server to be ready
+        if not asyncio.run(wait_for_server("http://localhost:8000")):
+            print("vLLM server failed to start within timeout.")
+            if vllm_process:
+                vllm_process.terminate()
+                stdout, _ = vllm_process.communicate()
+                print("vLLM Logs:")
+                print(stdout)
+            sys.exit(1)
+
+        # Run Orchestrator
+        print("Running Orchestrator...")
+        orch_command = [
+            sys.executable, "orchestrator.py",
+            "--url", "http://localhost:8000",
+            "--model", "facebook/opt-125m",
+            "--gpu", "micro-test-cpu",
+            "--concurrency-levels", "1",
+            "--requests-per-level", "2",
+            "--run"
+        ]
+
+        result = subprocess.run(orch_command, capture_output=True, text=True)
+        print("Orchestrator Output:")
+        print(result.stdout)
+        if result.returncode != 0:
+            print("Orchestrator failed:")
+            print(result.stderr)
+            sys.exit(1)
+
+        # Verify results
+        result_files = glob.glob("benchmark_micro-test-cpu_*.json")
+        if not result_files:
+            print("No benchmark result file found.")
+            sys.exit(1)
+
+        latest_file = max(result_files, key=os.path.getctime)
+        print(f"Verifying results in {latest_file}...")
+        with open(latest_file, "r") as f:
+            data = json.load(f)
+
+        if not isinstance(data, list) or len(data) == 0:
+            print("Invalid result data: expected a non-empty list.")
+            sys.exit(1)
+
+        metrics = data[0]
+        required_keys = ["avg_ttft", "avg_itl", "total_tps"]
+        for key in required_keys:
+            if key not in metrics or metrics[key] is None:
+                print(f"Missing or null metric: {key}")
+                sys.exit(1)
+
+        print("Micro runtime test PASSED!")
+
+    finally:
+        if vllm_process:
+            print("Stopping vLLM server...")
+            vllm_process.terminate()
+            try:
+                vllm_process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                vllm_process.kill()
+
+        # Cleanup result files
+        for f in glob.glob("benchmark_micro-test-cpu_*.json"):
+            os.remove(f)
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
Implemented a micro runtime test using the `facebook/opt-125m` model to provide a lightweight, automated verification path for the entire benchmarking stack. The new test is integrated into the GitHub Actions workflow and documented in `HOWTO.md` for local use.

Fixes #20

---
*PR created automatically by Jules for task [7501384025760468740](https://jules.google.com/task/7501384025760468740) started by @chatelao*