### PR TITLE
Support for Vast.ai templates and vLLM setup guide

### DIFF
--- a/HOWTO_VASTAI_TEMPLATE.md
+++ b/HOWTO_VASTAI_TEMPLATE.md
@@ -1,0 +1,44 @@
+# HOWTO: Using the Vast.ai vLLM Template
+
+This guide explains how to use the pre-configured Vast.ai template to deploy vLLM quickly. Using a template automates the server startup, reducing the number of manual steps required to start benchmarking.
+
+**Template Hash:** `7e24e4e5c2e551d012344a9bf4f141c2`
+
+## Option 1: Using the Vast.ai Web Console
+
+1.  **Go to the Create Instance Page:** Navigate to [vast.ai/console/create/](https://vast.ai/console/create/).
+2.  **Select the Template:**
+    - Click on **"EDIT IMAGE & CONFIG"**.
+    - Go to the **"Templates"** tab.
+    - Search for the template using the hash: `7e24e4e5c2e551d012344a9bf4f141c2` (or look for the vLLM template if available in the recommended list).
+    - Select it and click **"SELECT AND CLOSE"**.
+3.  **Find Hardware:** Search for your desired GPU (e.g., "RTX 4090").
+4.  **Rent:** Click **"RENT"** on your chosen offer.
+5.  **Wait for Ready:** The instance will automatically pull the Docker image and start the vLLM server. You can monitor the progress in the "Instances" tab.
+
+## Option 2: Using the Command Line (CLI)
+
+If you have the `vastai` CLI installed and configured, you can rent an instance using the template hash directly.
+
+1.  **Find an Offer ID:**
+    ```bash
+    vastai search offers 'gpu_name = RTX_4090'
+    ```
+2.  **Rent with Template:**
+    ```bash
+    vastai create instance <OFFER_ID> --template_hash 7e24e4e5c2e551d012344a9bf4f141c2 --disk 50
+    ```
+
+## Benefits of Using the Template
+
+-   **Automatic Startup:** The vLLM engine starts automatically upon instance creation.
+-   **Optimized Configuration:** The template comes with pre-configured environment variables and start commands.
+-   **Faster Setup:** No need to manually `docker run` via SSH, which saves time on expensive GPU instances.
+
+## Benchmarking with the Template
+
+Once the instance is ready and the API is up, you can run the orchestrator from your local machine (if it has network access to the instance) or from another inexpensive instance:
+
+```bash
+python3 orchestrator.py --gpu "RTX 4090" --model "gemma-2-9b-it" --url http://<INSTANCE_IP>:<PORT> --run
+```

--- a/infra/vast_manager.py
+++ b/infra/vast_manager.py
@@ -12,9 +12,14 @@ class VastManager:
         offers = self.sdk.search_offers(query=query, order="dph_total")
         return offers
 
-    def rent_instance(self, offer_id, image="nvidia/cuda:12.1.1-devel-ubuntu22.04", disk=50):
-        print(f"Attempting to rent offer {offer_id} with image {image}...")
-        result = self.sdk.create_instance(id=offer_id, image=image, disk=disk)
+    def rent_instance(self, offer_id, image="nvidia/cuda:12.1.1-devel-ubuntu22.04", disk=50, template_hash=None):
+        if template_hash:
+            print(f"Attempting to rent offer {offer_id} using template {template_hash}...")
+            result = self.sdk.create_instance(id=offer_id, template_hash=template_hash, disk=disk)
+        else:
+            print(f"Attempting to rent offer {offer_id} with image {image}...")
+            result = self.sdk.create_instance(id=offer_id, image=image, disk=disk)
+
         if result.get("success"):
             instance_id = result.get("new_contract")
             print(f"Successfully created instance {instance_id}")

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -33,7 +33,7 @@ class Orchestrator:
         print("Timeout waiting for API to be ready.")
         return False
 
-    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=600, prompt="Explain quantum physics in one sentence."):
+    async def run_suite(self, gpu_name, model_name, url=None, template_hash=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=600, prompt="Explain quantum physics in one sentence."):
         print(f"Starting benchmark suite for {model_name} on {gpu_name}")
 
         instance_id = None
@@ -49,7 +49,7 @@ class Orchestrator:
 
             # Select the best offer (lowest price per hour)
             offer_id = offers[0]['id']
-            instance_id = self.vast.rent_instance(offer_id)
+            instance_id = self.vast.rent_instance(offer_id, template_hash=template_hash)
             if not instance_id:
                 return
 
@@ -115,6 +115,7 @@ if __name__ == "__main__":
     parser.add_argument("--gpu", type=str, default="RTX_4090", help="GPU model to test")
     parser.add_argument("--model", type=str, default="gemma-7b", help="Model name")
     parser.add_argument("--url", type=str, help="Existing API endpoint URL (skips provisioning)")
+    parser.add_argument("--template-hash", type=str, help="Vast.ai template hash to use for provisioning")
     parser.add_argument("--run", action="store_true", help="Actually run the suite (requires Vast.ai credits)")
     parser.add_argument("--concurrency-levels", type=int, nargs="+", default=[1, 4, 16], help="Concurrency levels to test")
     parser.add_argument("--requests-per-level", type=int, default=10, help="Number of requests per concurrency level")
@@ -129,6 +130,7 @@ if __name__ == "__main__":
             args.gpu,
             args.model,
             url=args.url,
+            template_hash=args.template_hash,
             concurrency_levels=args.concurrency_levels,
             requests_per_level=args.requests_per_level,
             wait_timeout=args.wait_timeout,

--- a/tests/test_template_logic.py
+++ b/tests/test_template_logic.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from infra.vast_manager import VastManager
+from orchestrator import Orchestrator
+import asyncio
+
+class TestTemplateLogic(unittest.TestCase):
+    def test_vast_manager_template(self):
+        sdk_mock = MagicMock()
+        with patch('infra.vast_manager.VastAI', return_value=sdk_mock):
+            mgr = VastManager(api_key="fake")
+            mgr.rent_instance(123, template_hash="hash123", disk=40)
+            sdk_mock.create_instance.assert_called_with(id=123, template_hash="hash123", disk=40)
+
+            mgr.rent_instance(456, image="img456", disk=20)
+            sdk_mock.create_instance.assert_called_with(id=456, image="img456", disk=20)
+
+    @patch('orchestrator.VastManager')
+    def test_orchestrator_template_pass_through(self, mock_vast_mgr_class):
+        mock_vast_mgr = mock_vast_mgr_class.return_value
+        mock_vast_mgr.find_offers.return_value = [{'id': 789}]
+        mock_vast_mgr.rent_instance.return_value = 1010
+        mock_vast_mgr.wait_for_ssh.return_value = {'ssh_host': 'localhost', 'ssh_port': 8000}
+
+        orch = Orchestrator(api_key="fake")
+        # Mock wait_for_api_ready to return True immediately
+        orch.wait_for_api_ready = MagicMock(return_value=asyncio.Future())
+        orch.wait_for_api_ready.return_value.set_result(True)
+
+        # Mock tester.run_benchmark
+        with patch('orchestrator.LoadTester') as mock_tester_class:
+            mock_tester = mock_tester_class.return_value
+            mock_tester.run_benchmark.return_value = asyncio.Future()
+            mock_tester.run_benchmark.return_value.set_result({'total_tps': 10})
+
+            asyncio.run(orch.run_suite("GPU", "MODEL", template_hash="myhash", concurrency_levels=[1], requests_per_level=1))
+
+            mock_vast_mgr.rent_instance.assert_called_with(789, template_hash="myhash")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change introduces support for Vast.ai templates in the automated benchmarking framework. 

Key additions:
- **HOWTO_VASTAI_TEMPLATE.md**: A new guide explaining how to use the pre-configured vLLM template (hash `7e24e4e5c2e551d012344a9bf4f141c2`) via both the Vast.ai Web Console and CLI.
- **VastManager update**: Modified `infra/vast_manager.py` to allow `rent_instance` to take an optional `template_hash`.
- **Orchestrator update**: Added a `--template-hash` argument to `orchestrator.py`, enabling full automation of template-based deployments.
- **Testing**: Included a new unit test `tests/test_template_logic.py` to ensure the template hash is correctly passed through the stack.

Using templates significantly speeds up the benchmarking process by automating the vLLM server startup, reducing manual configuration steps on expensive GPU instances.

Fixes #23

---
*PR created automatically by Jules for task [1459166952930848561](https://jules.google.com/task/1459166952930848561) started by @chatelao*