### PR TITLE
Implement Email Notifications and Auto-Shutdown for Vast.ai Automation

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -78,3 +78,46 @@ To use a template with our tools, find your template's **Hash ID** in the Vast.a
 ```python
 mgr.rent_instance(offer_id, template_hash="your_template_hash")
 ```
+
+## Phase 6: Full Automation (Benchmark, Email, and Shutdown)
+For maximum efficiency, you can automate the entire workflow so that the instance runs the tests, emails you the results, and shuts itself down immediately.
+
+### 1. Create a Vast.ai Template
+In the [Vast.ai Console](https://vast.ai/console/templates/), create a new template with:
+- **Image:** `vllm/vllm-openai:v0.4.0` (or your preferred engine).
+- **Docker Options:** `-v ~/.cache/huggingface:/root/.cache/huggingface -p 8000:8000 --gpus all`.
+- **On-start Script:**
+  ```bash
+  # Start vLLM in the background
+  python3 -m vllm.entrypoints.openai.api_server \
+          --model google/gemma-2-9b-it \
+          --max-model-len 512 \
+          --block-size 16 \
+          --dtype float \
+          --enforce-eager > vllm.log 2>&1 &
+
+  # Clone and setup benchmarking tools
+  git clone <repo-url> /root/avast-ai-tests
+  cd /root/avast-ai-tests
+  pip install -r requirements.txt
+
+  # Run the orchestrator with email and auto-shutdown
+  # Ensure all necessary environment variables are set in the template
+  python3 orchestrator.py --url http://localhost:8000 \
+                          --model "gemma-2-9b-it" \
+                          --gpu "RTX 4090" \
+                          --run \
+                          --email "your-email@example.com" \
+                          --shutdown
+  ```
+
+### 2. Required Environment Variables
+Add these to your template's "Environment Variables" section:
+- `HF_TOKEN`: Your Hugging Face token.
+- `VAST_API_KEY`: Your Vast.ai API key (required for auto-shutdown).
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: For email notifications.
+
+### 3. Benefits of this Workflow
+- **No Manual Intervention:** Just click "Rent" and wait for the email.
+- **Zero Waste:** The instance is destroyed the second the benchmark is finished.
+- **Reproducibility:** The template ensures every test runs in an identical environment.

--- a/infra/vast_manager.py
+++ b/infra/vast_manager.py
@@ -47,6 +47,24 @@ class VastManager:
         print(f"Destroying instance {instance_id}...")
         return self.sdk.destroy_instance(id=instance_id)
 
+    def get_current_instance_id(self):
+        """Identifies the current Vast.ai instance ID by matching its public IP."""
+        try:
+            import urllib.request
+            # Get public IP of the current machine
+            public_ip = urllib.request.urlopen('https://api.ipify.org').read().decode('utf8')
+            print(f"Detected public IP: {public_ip}")
+
+            instances = self.sdk.show_instances()
+            # Find instance that matches this public IP
+            for inst in instances:
+                if inst.get('public_ipaddr') == public_ip or inst.get('ssh_host') == public_ip:
+                    print(f"Matched with instance ID: {inst['id']}")
+                    return inst['id']
+        except Exception as e:
+            print(f"Error detecting current instance ID: {e}")
+        return None
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Vast.ai Instance Manager")
     parser.add_argument("--search", type=str, help="Search for GPUs by name")

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -3,6 +3,9 @@ import json
 import time
 import argparse
 import aiohttp
+import os
+import smtplib
+from email.mime.text import MIMEText
 from infra.vast_manager import VastManager
 from bench.load_tester import LoadTester
 
@@ -33,7 +36,28 @@ class Orchestrator:
         print("Timeout waiting for API to be ready.")
         return False
 
-    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=600, prompt="Explain quantum physics in one sentence."):
+    def send_email_report(self, results, recipient, smtp_config):
+        """Sends a benchmark report via email."""
+        print(f"Sending email report to {recipient}...")
+        try:
+            body = "LLM Benchmark Results:\n\n"
+            body += json.dumps(results, indent=2)
+
+            msg = MIMEText(body)
+            msg['Subject'] = f"Benchmark Results: {results[0]['model']} on {results[0]['gpu']}"
+            msg['From'] = smtp_config.get('user')
+            msg['To'] = recipient
+
+            with smtplib.SMTP(smtp_config.get('host'), smtp_config.get('port')) as server:
+                if smtp_config.get('user') and smtp_config.get('password'):
+                    server.starttls()
+                    server.login(smtp_config.get('user'), smtp_config.get('password'))
+                server.send_message(msg)
+            print("Email sent successfully!")
+        except Exception as e:
+            print(f"Failed to send email: {e}")
+
+    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=600, prompt="Explain quantum physics in one sentence.", email_config=None, shutdown_at_exit=False):
         print(f"Starting benchmark suite for {model_name} on {gpu_name}")
 
         instance_id = None
@@ -102,6 +126,10 @@ class Orchestrator:
                 with open(report_file, "w") as f:
                     json.dump(all_results, f, indent=2)
                 print(f"Suite complete. Results saved to {report_file}")
+
+                # 4.5 Send email if configured
+                if email_config and email_config.get('to'):
+                    self.send_email_report(all_results, email_config['to'], email_config['smtp'])
             else:
                 print("No results collected.")
 
@@ -109,6 +137,14 @@ class Orchestrator:
             # 5. Teardown
             if instance_id:
                 self.vast.destroy_instance(instance_id)
+            elif shutdown_at_exit:
+                # If we are running on the instance itself, try to self-destruct
+                print("Shutdown requested. Attempting to identify current instance ID...")
+                self_id = self.vast.get_current_instance_id()
+                if self_id:
+                    self.vast.destroy_instance(self_id)
+                else:
+                    print("Could not identify current instance ID for auto-shutdown.")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Gemma Performance Lab Orchestrator")
@@ -121,10 +157,32 @@ if __name__ == "__main__":
     parser.add_argument("--wait-timeout", type=int, default=600, help="Timeout in seconds to wait for API to be ready")
     parser.add_argument("--prompt", type=str, default="Explain quantum physics in one sentence.", help="Prompt to use for benchmarking")
 
+    # Email arguments
+    parser.add_argument("--email", type=str, help="Recipient email address for results")
+    parser.add_argument("--smtp-host", type=str, default=os.getenv("SMTP_HOST"), help="SMTP server host")
+    parser.add_argument("--smtp-port", type=int, default=int(os.getenv("SMTP_PORT", "587")), help="SMTP server port")
+    parser.add_argument("--smtp-user", type=str, default=os.getenv("SMTP_USER"), help="SMTP username")
+    parser.add_argument("--smtp-password", type=str, default=os.getenv("SMTP_PASSWORD"), help="SMTP password")
+
+    # Shutdown argument
+    parser.add_argument("--shutdown", action="store_true", help="Auto-shutdown the Vast.ai instance after completion")
+
     args = parser.parse_args()
     orch = Orchestrator()
 
     if args.run:
+        email_config = None
+        if args.email:
+            email_config = {
+                'to': args.email,
+                'smtp': {
+                    'host': args.smtp_host,
+                    'port': args.smtp_port,
+                    'user': args.smtp_user,
+                    'password': args.smtp_password
+                }
+            }
+
         asyncio.run(orch.run_suite(
             args.gpu,
             args.model,
@@ -132,7 +190,9 @@ if __name__ == "__main__":
             concurrency_levels=args.concurrency_levels,
             requests_per_level=args.requests_per_level,
             wait_timeout=args.wait_timeout,
-            prompt=args.prompt
+            prompt=args.prompt,
+            email_config=email_config,
+            shutdown_at_exit=args.shutdown
         ))
     else:
         print("Orchestrator initialized.")


### PR DESCRIPTION
This PR implements full automation for LLM benchmarking on Vast.ai. 

Key changes:
1.  **Infrastructure Enhancement**: `VastManager` now has a `get_current_instance_id` method that allows an instance to identify itself by its public IP, enabling reliable self-destruction.
2.  **Email Notifications**: The `Orchestrator` can now send benchmark results via email using SMTP. New CLI flags allow configuring the recipient and SMTP server details.
3.  **Auto-Shutdown**: A new `--shutdown` flag in `orchestrator.py` triggers the instance to destroy itself immediately after the benchmark suite and email reporting are finished.
4.  **Documentation**: `HOWTO.md` has been updated with "Phase 6: Full Automation," providing users with a step-by-step guide on creating Vast.ai templates with automated on-start scripts.

These features enable a "hands-off" benchmarking workflow where a user can simply rent an instance from a template and receive the results in their inbox, with the instance automatically cleaning itself up to minimize costs.

Fixes #26

---
*PR created automatically by Jules for task [13938754746899220920](https://jules.google.com/task/13938754746899220920) started by @chatelao*