### PR TITLE
Add models as selections to the GH benchmark workflow

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -8,9 +8,17 @@ on:
         required: true
         default: 'RTX_4090'
       model:
-        description: 'LLM model name (e.g., google/gemma-2-9b-it)'
+        description: 'LLM model name'
         required: true
         default: 'google/gemma-2-9b-it'
+        type: choice
+        options:
+        - 'facebook/opt-125m'
+        - 'google/gemma-4-E2B-it'
+        - 'google/gemma-4-E4B-it'
+        - 'google/gemma-2-9b-it'
+        - 'mistralai/Mistral-Small-Instruct-2409'
+        - 'mistralai/Mistral-Large-Instruct-2411'
       concurrency_levels:
         description: 'Space-separated concurrency levels'
         required: true


### PR DESCRIPTION
Added selectable model options to the Vast.ai LLM Benchmark workflow. The `model` input is now a dropdown selection containing:
- Smallest Facebook: `facebook/opt-125m`
- Smallest Gemma 4: `google/gemma-4-E2B-it`
- Second Smallest Gemma 4: `google/gemma-4-E4B-it`
- Medium Mistral: `mistralai/Mistral-Small-Instruct-2409`
- Large Mistral: `mistralai/Mistral-Large-Instruct-2411`
- Existing default: `google/gemma-2-9b-it`

Verified the workflow syntax and ensured that existing tests pass.

Fixes #30

---
*PR created automatically by Jules for task [16864502351141597483](https://jules.google.com/task/16864502351141597483) started by @chatelao*