### PR TITLE
Add shutdown sequence to workflow if cancelled

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -60,6 +60,20 @@ jobs:
 
     - name: Upload results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: benchmark-results
         path: benchmark_*.json
+
+    - name: Cleanup Vast.ai Instance
+      if: always()
+      env:
+        VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
+      run: |
+        if [ -f .vast_instance_id ]; then
+          INSTANCE_ID=$(cat .vast_instance_id)
+          echo "Cleanup: Destroying instance $INSTANCE_ID"
+          python infra/vast_manager.py --destroy $INSTANCE_ID
+        else
+          echo "No .vast_instance_id found, skipping cleanup."
+        fi

--- a/infra/vast_manager.py
+++ b/infra/vast_manager.py
@@ -1,11 +1,13 @@
 import argparse
 import time
 import sys
+import os
 from vastai.sdk import VastAI
 
 class VastManager:
     def __init__(self, api_key=None):
-        self.sdk = VastAI(api_key=api_key)
+        self.api_key = api_key or os.getenv("VAST_AI_API_KEY")
+        self.sdk = VastAI(api_key=self.api_key)
 
     def find_offers(self, gpu_name, num_gpus=1):
         query = f"gpu_name={gpu_name} num_gpus={num_gpus} rentable=True verified=True"

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -77,6 +77,10 @@ class Orchestrator:
             if not instance_id:
                 return
 
+            # Persist instance ID for external cleanup (e.g., GitHub Actions cancellation)
+            with open(".vast_instance_id", "w") as f:
+                f.write(str(instance_id))
+
         try:
             if not url:
                 # 2. Wait for instance to be ready
@@ -143,6 +147,8 @@ class Orchestrator:
             # 5. Teardown
             if instance_id:
                 self.vast.destroy_instance(instance_id)
+                if os.path.exists(".vast_instance_id"):
+                    os.remove(".vast_instance_id")
             elif shutdown_at_exit:
                 # If we are running on the instance itself, try to self-destruct
                 print("Shutdown requested. Attempting to identify current instance ID...")


### PR DESCRIPTION
This change ensures that Vast.ai instances rented during a benchmark run are properly destroyed even if the GitHub Actions workflow is cancelled or fails.

It implements this by:
1.  **Persistence:** The `orchestrator.py` script now writes the `instance_id` to a local file `.vast_instance_id` immediately after renting an instance.
2.  **Environment-based Auth:** `VastManager` was updated to automatically pick up the `VAST_AI_API_KEY` from the environment, facilitating its use in separate workflow steps.
3.  **Workflow Cleanup:** A new step was added to the `.github/workflows/vast_ai_benchmark.yml` workflow with `if: always()`. This step checks for the existence of `.vast_instance_id` and, if found, uses the `infra/vast_manager.py` CLI to destroy the instance.
4.  **Robustness:** The "Upload results" step in the workflow was also updated to run `always()` to ensure any generated logs or partial results are preserved.

Fixes #31

---
*PR created automatically by Jules for task [5297121993107308190](https://jules.google.com/task/5297121993107308190) started by @chatelao*