### PR TITLE
Set default Vast.ai template hash and support preinstalled vLLM

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -30,6 +30,7 @@ on:
       template_hash:
         description: 'Vast.ai template hash (optional)'
         required: false
+        default: '38b2b68cf896e8582dff6f305a2041b1'
       prompt:
         description: 'Benchmark prompt'
         required: true

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -74,9 +74,12 @@ Using a **Vast.ai Template** (configured via the Web Console) is significantly f
 - **Zero-Touch:** You can configure the `docker run` command and environment variables (like `HF_TOKEN`) directly in the template.
 - **Parallelism:** The engine starts while you are still SSHing in to clone the benchmarking repo.
 
-To use a template with our tools, find your template's **Hash ID** in the Vast.ai console and pass it to the orchestrator (if supported) or use it in `vast_manager.py`:
+To use a template with our tools, find your template's **Hash ID** in the Vast.ai console and pass it to the orchestrator (if supported) or use it in `vast_manager.py`.
+
+Our recommended template hash is `38b2b68cf896e8582dff6f305a2041b1`, which comes with **vLLM preinstalled and ready to go**.
+
 ```python
-mgr.rent_instance(offer_id, template_hash="your_template_hash")
+mgr.rent_instance(offer_id, template_hash="38b2b68cf896e8582dff6f305a2041b1")
 ```
 
 ## Phase 6: Full Automation (Benchmark, Email, and Shutdown)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -99,7 +99,10 @@ class Orchestrator:
                 # Example:
                 # ssh.exec_command("docker run -d --gpus all -p 8000:8000 vllm/vllm-openai --model gemma-2-9b-it --max-model-len 512 --block-size 16")
 
-                print("To complete the test, ensure the LLM engine is running on the remote host.")
+                if template_hash:
+                    print(f"Using template {template_hash}. Waiting for preinstalled vLLM to start...")
+                else:
+                    print("To complete the test, ensure the LLM engine is running on the remote host.")
                 print(f"URL: {api_url}")
 
             # 2.5 Wait for API to be ready
@@ -162,7 +165,7 @@ if __name__ == "__main__":
     parser.add_argument("--requests-per-level", type=int, default=10, help="Number of requests per concurrency level")
     parser.add_argument("--wait-timeout", type=int, default=600, help="Timeout in seconds to wait for API to be ready")
     parser.add_argument("--prompt", type=str, default="Explain quantum physics in one sentence.", help="Prompt to use for benchmarking")
-    parser.add_argument("--template-hash", type=str, help="Vast.ai template hash to use for provisioning")
+    parser.add_argument("--template-hash", type=str, default="38b2b68cf896e8582dff6f305a2041b1", help="Vast.ai template hash to use for provisioning")
 
     # Email arguments
     parser.add_argument("--email", type=str, help="Recipient email address for results")


### PR DESCRIPTION
This change sets a new default Vast.ai template hash (38b2b68cf896e8582dff6f305a2041b1) across the orchestrator CLI, GitHub Actions workflow, and documentation. It also improves the orchestrator's output by specifically mentioning that it is waiting for the preinstalled vLLM engine when a template is utilized, rather than providing manual setup instructions.

Fixes #34

---
*PR created automatically by Jules for task [8282271706191122707](https://jules.google.com/task/8282271706191122707) started by @chatelao*