### PR TITLE
Fix benchmark failures and model weight downloads on Vast.ai

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -28,8 +28,9 @@ on:
         required: true
         default: '10'
       template_hash:
-        description: 'Vast.ai template hash (optional)'
-        required: false
+        description: 'Vast.ai template hash'
+        required: true
+        default: '7e24e4e5c2e551d012344a9bf4f141c2'
       prompt:
         description: 'Benchmark prompt'
         required: true

--- a/infra/vast_manager.py
+++ b/infra/vast_manager.py
@@ -14,12 +14,12 @@ class VastManager:
         offers = self.sdk.search_offers(query=query, order="dph_total")
         return offers
 
-    def rent_instance(self, offer_id, image="nvidia/cuda:12.1.1-devel-ubuntu22.04", disk=50, template_hash=None):
+    def rent_instance(self, offer_id, image="nvidia/cuda:12.1.1-devel-ubuntu22.04", disk=50, template_hash=None, env=None):
         if template_hash:
             print(f"Attempting to rent offer {offer_id} using template {template_hash}...")
         else:
             print(f"Attempting to rent offer {offer_id} with image {image}...")
-        result = self.sdk.create_instance(id=offer_id, image=image, disk=disk, template_hash=template_hash)
+        result = self.sdk.create_instance(id=offer_id, image=image, disk=disk, template_hash=template_hash, env=env)
         if result.get("success"):
             instance_id = result.get("new_contract")
             print(f"Successfully created instance {instance_id}")

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -73,7 +73,14 @@ class Orchestrator:
 
             # Select the best offer (lowest price per hour)
             offer_id = offers[0]['id']
-            instance_id = self.vast.rent_instance(offer_id, template_hash=template_hash)
+
+            # Pass HF_TOKEN if available
+            env_vars = {}
+            hf_token = os.getenv("HF_TOKEN")
+            if hf_token:
+                env_vars["HF_TOKEN"] = hf_token
+
+            instance_id = self.vast.rent_instance(offer_id, template_hash=template_hash, env=env_vars)
             if not instance_id:
                 return
 
@@ -94,7 +101,9 @@ class Orchestrator:
                 if '8000/tcp' in ports:
                     api_url = f"http://{ports['8000/tcp'][0]['DirectAddress']}"
                 else:
-                    api_url = f"http://{instance['ssh_host']}:{instance['ssh_port']}"
+                    print("Error: Port 8000 is not mapped on the instance.")
+                    print("Automated benchmarking requires port 8000 to be exposed (typically via a Vast.ai template).")
+                    return
 
                 print(f"Instance ready at {api_url}")
 

--- a/tests/test_template_logic.py
+++ b/tests/test_template_logic.py
@@ -51,7 +51,7 @@ class TestTemplateLogic(unittest.TestCase):
             ))
 
             # Verify rent_instance was called with template_hash
-            mock_vast.rent_instance.assert_called_with(123, template_hash="my_template_hash")
+            mock_vast.rent_instance.assert_called_with(123, template_hash="my_template_hash", env={})
 
     @patch("orchestrator.VastManager")
     def test_api_url_construction_with_mapped_port(self, MockVastManager):
@@ -89,7 +89,7 @@ class TestTemplateLogic(unittest.TestCase):
             MockLoadTester.assert_called_with("http://mapped.host:32768", "gemma")
 
     @patch("orchestrator.VastManager")
-    def test_api_url_construction_fallback(self, MockVastManager):
+    def test_api_url_construction_fails_without_mapping(self, MockVastManager):
         mock_vast = MockVastManager.return_value
         mock_vast.find_offers.return_value = [{"id": 123}]
         mock_vast.rent_instance.return_value = "inst_1"
@@ -101,16 +101,7 @@ class TestTemplateLogic(unittest.TestCase):
             "ports": {}
         }
 
-        async def mock_wait(*args, **kwargs):
-            return True
-        self.orchestrator.wait_for_api_ready = mock_wait
-
         with patch("orchestrator.LoadTester") as MockLoadTester:
-            mock_tester = MockLoadTester.return_value
-            async def mock_run_bench(*args, **kwargs):
-                return {"total_tps": 10.0}
-            mock_tester.run_benchmark = mock_run_bench
-
             asyncio.run(self.orchestrator.run_suite(
                 gpu_name="RTX_4090",
                 model_name="gemma",
@@ -118,8 +109,8 @@ class TestTemplateLogic(unittest.TestCase):
                 requests_per_level=1
             ))
 
-            # Check if LoadTester was initialized with the SSH URL fallback
-            MockLoadTester.assert_called_with("http://1.2.3.4:2222", "gemma")
+            # Check that LoadTester was NEVER called because we exited early
+            MockLoadTester.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The benchmark was failing because it defaulted to a base CUDA image without an LLM engine or port 8000 mapping, leading to health check timeouts on the SSH port. Additionally, gated models (like Gemma) failed to download due to a missing `HF_TOKEN` on the remote host. This PR fixes these issues by enforcing the use of Vast.ai templates, forwarding the `HF_TOKEN`, and ensuring proper API URL construction.

Fixes #35

---
*PR created automatically by Jules for task [10094412019741038554](https://jules.google.com/task/10094412019741038554) started by @chatelao*