### PR TITLE
Fix Vast.ai instance rental and improve error reporting

### DIFF
--- a/infra/vast_manager.py
+++ b/infra/vast_manager.py
@@ -4,6 +4,7 @@ import sys
 import os
 import requests
 from vastai.sdk import VastAI
+from vastai.utils import parse_env
 
 class VastManager:
     def __init__(self, api_key=None):
@@ -17,6 +18,8 @@ class VastManager:
             return offers
         except requests.exceptions.HTTPError as e:
             print(f"Error searching offers: {e}")
+            if e.response is not None:
+                print(f"Response: {e.response.text}")
             return []
         except Exception as e:
             print(f"Unexpected error searching offers: {e}")
@@ -29,10 +32,16 @@ class VastManager:
         else:
             print(f"Attempting to rent offer {offer_id} with image {image}...")
 
+        # If env is a string, parse it into a dictionary as expected by the SDK/API
+        if isinstance(env, str):
+            env = parse_env(env)
+
         try:
             result = self.sdk.create_instance(id=offer_id, image=image, disk=disk, template_hash=template_hash, env=env)
         except requests.exceptions.HTTPError as e:
             print(f"Error renting instance: {e}")
+            if e.response is not None:
+                print(f"Response: {e.response.text}")
             return None
         except Exception as e:
             print(f"Unexpected error renting instance: {e}")
@@ -54,6 +63,8 @@ class VastManager:
                 instances = self.sdk.show_instances()
             except requests.exceptions.HTTPError as e:
                 print(f"Error fetching instances: {e}")
+                if e.response is not None:
+                    print(f"Response: {e.response.text}")
                 return None
             except Exception as e:
                 print(f"Unexpected error fetching instances: {e}")
@@ -77,6 +88,8 @@ class VastManager:
             return self.sdk.destroy_instance(id=instance_id)
         except requests.exceptions.HTTPError as e:
             print(f"Error destroying instance {instance_id}: {e}")
+            if e.response is not None:
+                print(f"Response: {e.response.text}")
             return None
         except Exception as e:
             print(f"Unexpected error destroying instance {instance_id}: {e}")

--- a/tests/test_vast_manager_env.py
+++ b/tests/test_vast_manager_env.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from infra.vast_manager import VastManager
+
+class TestVastManagerEnv(unittest.TestCase):
+    @patch('infra.vast_manager.VastAI')
+    def test_rent_instance_converts_env_string_to_dict(self, mock_vastai):
+        # Setup
+        mock_sdk = MagicMock()
+        mock_vastai.return_value = mock_sdk
+        mock_sdk.create_instance.return_value = {"success": True, "new_contract": 12345}
+
+        mgr = VastManager(api_key="fake-key")
+
+        # Test with string env
+        env_string = "-e VAR1=VAL1 -e VAR2=VAL2 -p 8000:8000"
+        mgr.rent_instance(offer_id=111, env=env_string)
+
+        # Verify
+        expected_env = {
+            "VAR1": "VAL1",
+            "VAR2": "VAL2",
+            "-p 8000:8000": "1"
+        }
+        mock_sdk.create_instance.assert_called_with(
+            id=111,
+            image="nvidia/cuda:12.1.1-devel-ubuntu22.04",
+            disk=50,
+            template_hash=None,
+            env=expected_env
+        )
+
+    @patch('infra.vast_manager.VastAI')
+    def test_rent_instance_keeps_env_dict(self, mock_vastai):
+        # Setup
+        mock_sdk = MagicMock()
+        mock_vastai.return_value = mock_sdk
+        mock_sdk.create_instance.return_value = {"success": True, "new_contract": 12345}
+
+        mgr = VastManager(api_key="fake-key")
+
+        # Test with dict env
+        env_dict = {"VAR1": "VAL1"}
+        mgr.rent_instance(offer_id=111, env=env_dict)
+
+        # Verify
+        mock_sdk.create_instance.assert_called_with(
+            id=111,
+            image="nvidia/cuda:12.1.1-devel-ubuntu22.04",
+            disk=50,
+            template_hash=None,
+            env=env_dict
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes the "400 Client Error: Bad Request" that occurred when the orchestrator attempted to rent a Vast.ai instance. The fix involves ensuring that environment variables (and port mappings) are passed to the Vast.ai SDK as a dictionary rather than a string. Additionally, I've improved error reporting across all Vast.ai SDK interactions to print the full response body, which will provide much better visibility into future API errors. A new test file `tests/test_vast_manager_env.py` has been added to verify the conversion logic.

Fixes #42

---
*PR created automatically by Jules for task [17126816911531212692](https://jules.google.com/task/17126816911531212692) started by @chatelao*