### PR TITLE
Refactor benchmarking for local orchestration and remote templates

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -53,19 +53,30 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Run Orchestrator
+    - name: Start LLM Engine
       env:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
-        # Convert space-separated concurrency levels to what orchestrator expects (it uses nargs="+")
+        python orchestrator.py \
+          --gpu "${{ github.event.inputs.gpu }}" \
+          --model "${{ github.event.inputs.model }}" \
+          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }} \
+          --provision \
+          --run
+
+    - name: Run Benchmark Suite
+      env:
+        VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      run: |
         python orchestrator.py \
           --gpu "${{ github.event.inputs.gpu }}" \
           --model "${{ github.event.inputs.model }}" \
           --concurrency-levels ${{ github.event.inputs.concurrency_levels }} \
           --requests-per-level ${{ github.event.inputs.requests_per_level }} \
-          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }} \
           --prompt "${{ github.event.inputs.prompt }}" \
+          --benchmark \
           --run
 
     - name: Upload results
@@ -75,15 +86,9 @@ jobs:
         name: benchmark-results
         path: benchmark_*.json
 
-    - name: Cleanup Vast.ai Instance
+    - name: Stop LLM Engine
       if: always()
       env:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
       run: |
-        if [ -f .vast_instance_id ]; then
-          INSTANCE_ID=$(cat .vast_instance_id)
-          echo "Cleanup: Destroying instance $INSTANCE_ID"
-          python infra/vast_manager.py --destroy $INSTANCE_ID
-        else
-          echo "No .vast_instance_id found, skipping cleanup."
-        fi
+        python orchestrator.py --teardown --run

--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -28,7 +28,7 @@ on:
         required: true
         default: '10'
       template_hash:
-        description: 'Vast.ai template hash (optional)'
+        description: 'Vast.ai template hash'
         required: false
         default: '38b2b68cf896e8582dff6f305a2041b1'
       prompt:

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,133 +1,62 @@
-# HOWTO: From Zero to Test Results (On-Instance)
+# HOWTO: Benchmarking LLMs on Vast.ai
 
-This guide provides a step-by-step checklist to benchmark LLMs directly on a Vast.ai instance. Running benchmarks on-instance eliminates network latency and provides the most accurate hardware metrics.
+This guide describes how to benchmark LLMs on Vast.ai using this automated framework. The recommended approach is to use the provided GitHub Action workflow, which handles the entire lifecycle from provisioning to cleanup.
 
-## Phase 1: Preparation
-- [ ] **Vast.ai Account:** Create an account at [vast.ai](https://vast.ai/).
-- [ ] **Add Credits:** Ensure your account has a balance to rent instances.
-- [ ] **HuggingFace Token:** If testing gated models (like Gemma), get a token from [huggingface.co](https://huggingface.co/settings/tokens).
+## Primary Workflow: GitHub Actions (Automated)
 
-## Phase 2: Renting an Instance
-- [ ] **Search for Hardware:** Go to the [Vast.ai Console](https://vast.ai/console/create/) and search for your desired GPU (e.g., "RTX 4090").
-- [ ] **Rent:** Select an offer and rent the instance.
-- [ ] **Get SSH Details:** Once the instance is ready, note the SSH IP and Port from the "Instances" tab.
+Running benchmarks via GitHub Actions is the most reliable and efficient method. The orchestrator runs on the GitHub runner and manages a remote GPU instance on Vast.ai.
 
-## Phase 3: Optimized On-Instance Setup & Benchmarking
-To minimize runtime on expensive hardware, we maximize startup efficiency by running the LLM engine and setup tasks in parallel.
+### 1. Prerequisites
+- **Vast.ai API Key:** Get your API key from the [Vast.ai Console](https://vast.ai/console/billing/).
+- **HuggingFace Token:** For gated models (like Gemma), get a token from [HuggingFace Settings](https://huggingface.co/settings/tokens).
+- **GitHub Secrets:** Add `VAST_AI_API_KEY` and `HF_TOKEN` to your repository's GitHub Actions secrets.
 
-- [ ] **SSH and Start LLM Engine Immediately:**
-  Run the engine in detached mode (`-d`) so it starts pulling the model while you finish setup.
-  ```bash
-  ssh -p <PORT> root@<IP>
-  # Recommendation: use the module entrypoint for better stability in some environments
-  # python -m vllm.entrypoints.openai.api_server --model google/gemma-2-9b-it ...
-  docker run -d --gpus all \
-             -v ~/.cache/huggingface:/root/.cache/huggingface \
-             -e HF_TOKEN=<your_token> \
-             -p 8000:8000 vllm/vllm-openai:v0.4.0 \
-             --model google/gemma-2-9b-it \
-             --max-model-len 512 \
-             --block-size 16 \
-             --dtype float \
-             --enforce-eager
-  ```
-- [ ] **Setup Benchmarking Tools (Parallel to Download):**
-  While the Docker image is pulling in the background, clone the repo and install requirements.
-  ```bash
-  git clone <repo-url>
-  cd avast-ai-tests
-  pip install -r requirements.txt
-  ```
-- [ ] **Run Orchestrator with Auto-Ready:**
-  The orchestrator will automatically wait for the API to be ready before starting the benchmark.
-  ```bash
-  python3 orchestrator.py --gpu "RTX 4090" --model "gemma-2-9b-it" --url http://localhost:8000 --run
-  ```
+### 2. Running the Benchmark
+- Go to the **Actions** tab in your GitHub repository.
+- Select the **Vast.ai LLM Benchmark** workflow.
+- Click **Run workflow**.
+- Configure the inputs:
+    - **GPU model:** e.g., `RTX_4090`, `A100`.
+    - **LLM model:** Choose from the predefined list.
+    - **Concurrency levels:** Space-separated list (e.g., `1 4 16`).
+    - **Template Hash:** Use the default optimized vLLM template.
+- Click **Run workflow**.
 
-## Phase 4: Analyze Results & Immediate Cleanup
-To avoid unnecessary charges, analyze your results and destroy the instance immediately.
-- [ ] **Check Output File:** Results are saved as `benchmark_<gpu>_<timestamp>.json`.
-- [ ] **Verify Metrics:**
-    - **TTFT:** Time to First Token (lower is better).
-    - **ITL:** Inter-Token Latency (lower is better).
-    - **TPS:** Tokens Per Second (higher is better).
+### 3. Viewing Results
+- Once the workflow completes, the results table will be displayed in the **GitHub Step Summary**.
+- Detailed JSON results are available as a workflow artifact named `benchmark-results`.
+- The instance is automatically destroyed at the end of the workflow, even if a failure occurs.
 
-## Local Verification (Micro Runtime Test)
-If you want to verify the entire stack (Orchestrator + Load Tester + vLLM) without renting a GPU, you can run the micro runtime test on your local CPU. This uses a tiny 125M parameter model.
+## Manual Workflow (CLI-based)
 
-- [ ] **Install vLLM-CPU:**
-  ```bash
-  pip install vllm-cpu --extra-index-url https://download.pytorch.org/whl/cpu
-  ```
-- [ ] **Run the Test:**
-  ```bash
-  python tests/micro_runtime_test.py
-  ```
-This script automates the server startup, benchmarking, and result verification.
+You can also run the orchestrator manually from your local machine.
 
-## Phase 5: Fast Cleanup
-- [ ] **Destroy Instance:** Immediately go back to the [Vast.ai Console](https://vast.ai/console/instances/) and destroy the instance. For expensive hardware, every minute counts.
-
-## Pro Tip: Using Templates for Even Faster Setup
-Using a **Vast.ai Template** (configured via the Web Console) is significantly faster than manual `docker run` because:
-- **Instant Pull:** The host starts pulling the vLLM image the moment the instance is provisioned.
-- **Zero-Touch:** You can configure the `docker run` command and environment variables (like `HF_TOKEN`) directly in the template.
-- **Parallelism:** The engine starts while you are still SSHing in to clone the benchmarking repo.
-
-To use a template with our tools, find your template's **Hash ID** in the Vast.ai console and pass it to the orchestrator (if supported) or use it in `vast_manager.py`.
-
-Our recommended template hash is `7e24e4e5c2e551d012344a9bf4f141c2`, which provides a highly optimized **vLLM Inference Engine**.
-
-### Environment-Based Configuration
-This template is configured entirely via environment variables, which our orchestrator handles automatically:
-- `VLLM_MODEL`: The Hugging Face model path.
-- `VLLM_ARGS`: Optimization flags like `--max-model-len 512`.
-- `HF_TOKEN`: Your Hugging Face token for gated models.
-- `OPEN_BUTTON_TOKEN`: Sets the API key for the vLLM server.
-
-```python
-mgr.rent_instance(offer_id, template_hash="7e24e4e5c2e551d012344a9bf4f141c2", env="-e VLLM_MODEL=google/gemma-2-9b-it ...")
+### 1. Installation
+```bash
+pip install -r requirements.txt
+export VAST_AI_API_KEY=your_key
+export HF_TOKEN=your_hf_token
 ```
 
-## Phase 6: Full Automation (Benchmark, Email, and Shutdown)
-For maximum efficiency, you can automate the entire workflow so that the instance runs the tests, emails you the results, and shuts itself down immediately.
+### 2. Execution
+The orchestrator will provision an instance using the optimized vLLM template, run the benchmarks, and then destroy the instance.
 
-### 1. Create a Vast.ai Template
-In the [Vast.ai Console](https://vast.ai/console/templates/), create a new template with:
-- **Image:** `vllm/vllm-openai:v0.4.0` (or your preferred engine).
-- **Docker Options:** `-v ~/.cache/huggingface:/root/.cache/huggingface -p 8000:8000 --gpus all`.
-- **On-start Script:**
-  ```bash
-  # Start vLLM in the background
-  python3 -m vllm.entrypoints.openai.api_server \
-          --model google/gemma-2-9b-it \
-          --max-model-len 512 \
-          --block-size 16 \
-          --dtype float \
-          --enforce-eager > vllm.log 2>&1 &
+```bash
+python3 orchestrator.py --gpu "RTX_4090" --model "google/gemma-2-9b-it" --run
+```
 
-  # Clone and setup benchmarking tools
-  git clone <repo-url> /root/avast-ai-tests
-  cd /root/avast-ai-tests
-  pip install -r requirements.txt
+## Local Verification (No GPU required)
 
-  # Run the orchestrator with email and auto-shutdown
-  # Ensure all necessary environment variables are set in the template
-  python3 orchestrator.py --url http://localhost:8000 \
-                          --model "gemma-2-9b-it" \
-                          --gpu "RTX 4090" \
-                          --run \
-                          --email "your-email@example.com" \
-                          --shutdown
-  ```
+To verify the scripting logic without renting a GPU, use the micro runtime test.
 
-### 2. Required Environment Variables
-Add these to your template's "Environment Variables" section:
-- `HF_TOKEN`: Your Hugging Face token.
-- `VAST_API_KEY`: Your Vast.ai API key (required for auto-shutdown).
-- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`: For email notifications.
+```bash
+pip install vllm-cpu --extra-index-url https://download.pytorch.org/whl/cpu
+python tests/micro_runtime_test.py
+```
 
-### 3. Benefits of this Workflow
-- **No Manual Intervention:** Just click "Rent" and wait for the email.
-- **Zero Waste:** The instance is destroyed the second the benchmark is finished.
-- **Reproducibility:** The template ensures every test runs in an identical environment.
+## Architecture Details
+
+This framework relies on optimized Vast.ai templates. The default template (`7e24e4e5c2e551d012344a9bf4f141c2`) is pre-configured with:
+- **vLLM Engine:** For high-throughput inference.
+- **Auto-Config:** Uses environment variables (`VLLM_MODEL`, `HF_TOKEN`, `OPEN_BUTTON_TOKEN`) for zero-touch setup.
+- **Port Mapping:** Exposes vLLM on port 8000 for the orchestrator to connect.

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -45,6 +45,11 @@ The orchestrator will provision an instance using the optimized vLLM template, r
 python3 orchestrator.py --gpu "RTX_4090" --model "google/gemma-2-9b-it" --run
 ```
 
+The orchestrator also supports granular execution modes, which are used by the GitHub Actions workflow:
+- `--provision`: Just rent the instance and wait for the API to be ready.
+- `--benchmark`: Run the benchmark suite against an already provisioned instance.
+- `--teardown`: Destroy the provisioned instance.
+
 ## Local Verification (No GPU required)
 
 To verify the scripting logic without renting a GPU, use the micro runtime test.
@@ -56,7 +61,7 @@ python tests/micro_runtime_test.py
 
 ## Architecture Details
 
-This framework relies on optimized Vast.ai templates. The default template (`7e24e4e5c2e551d012344a9bf4f141c2`) is pre-configured with:
+This framework relies on optimized Vast.ai templates. The default template (`38b2b68cf896e8582dff6f305a2041b1`) is pre-configured with:
 - **vLLM Engine:** For high-throughput inference.
 - **Auto-Config:** Uses environment variables (`VLLM_MODEL`, `HF_TOKEN`, `OPEN_BUTTON_TOKEN`) for zero-touch setup.
-- **Port Mapping:** Exposes vLLM on port 8000 for the orchestrator to connect.
+- **Port Mapping:** Exposes vLLM on port 18000 for the orchestrator to connect.

--- a/bench/load_tester.py
+++ b/bench/load_tester.py
@@ -76,9 +76,17 @@ class LoadTester:
 
             # Simple concurrency control
             semaphore = asyncio.Semaphore(concurrency)
+            completed = 0
+            total = len(tasks)
+
             async def sem_request(task):
+                nonlocal completed
                 async with semaphore:
-                    return await task
+                    res = await task
+                    completed += 1
+                    if completed % 5 == 0 or completed == total:
+                        print(f"  Progress: {completed}/{total} requests finished")
+                    return res
 
             results = await asyncio.gather(*(sem_request(t) for t in tasks))
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -102,17 +102,21 @@ class Orchestrator:
         except Exception as e:
             print(f"Failed to send email: {e}")
 
-    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=1200, prompt="Explain quantum physics in one sentence.", email_config=None, shutdown_at_exit=False, template_hash=None):
+    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=1200, prompt="Explain quantum physics in one sentence.", email_config=None, template_hash="38b2b68cf896e8582dff6f305a2041b1"):
         print(f"Starting benchmark suite for {model_name} on {gpu_name}")
 
         instance_id = None
-        env_vars = None
         vllm_api_key = "vllm-benchmark-token"
 
         if url:
             api_url = url
             print(f"Using existing endpoint: {api_url}")
+            # Ensure instance_id is None to avoid teardown of existing endpoint if URL is used
+            instance_id = None
         else:
+            if not template_hash:
+                raise ValueError("template_hash is required when provisioning a new instance")
+
             self.log_group_start("Instance Provisioning")
             try:
                 # 1. Find and rent instance
@@ -122,12 +126,8 @@ class Orchestrator:
                     # Force exit with error code if we can't find offers and were supposed to run
                     raise RuntimeError(f"Could not find any offers for {gpu_name}")
 
-                # if template_hash == "7e24e4e5c2e551d012344a9bf4f141c2":
-                # vllm_args = "--api-key vllm-benchmark-token --max-model-len 512 --block-size 16 --dtype float --enforce-eager"
-                # env_vars = f"-e VLLM_MODEL={model_name} -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 8000:18000"
-
                 hf_token = os.getenv("HF_TOKEN", "")
-                env_vars = f"-e VLLM_MODEL={model_name} -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 8000:18000"
+                env_vars = f"-e VLLM_MODEL={model_name} -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 18000:18000"
 
                 # Select the best offer (lowest price per hour)
                 offer_id = offers[0]['id']
@@ -150,19 +150,15 @@ class Orchestrator:
                     if not instance:
                         raise RuntimeError(f"Instance {instance_id} failed to initialize or become reachable")
 
-                    # Determine API URL, prioritizing mapped port 8000
+                    # Determine API URL, prioritizing mapped port 18000
                     ports = instance.get('ports', {})
-                    if '8000/tcp' in ports:
-                        api_url = f"http://{ports['8000/tcp'][0]['DirectAddress']}"
+                    if '18000/tcp' in ports:
+                        api_url = f"http://{ports['18000/tcp'][0]['DirectAddress']}"
                     else:
-                        api_url = f"http://{instance['ssh_host']}:{instance['ssh_port']}"
+                        raise RuntimeError(f"Instance {instance_id} does not have port 18000 mapped. vLLM template requires port 18000.")
 
                     print(f"Instance ready at {api_url}")
-
-                    if template_hash:
-                        print(f"Using template {template_hash}. Waiting for preinstalled vLLM to start...")
-                    else:
-                        print("To complete the test, ensure the LLM engine is running on the remote host.")
+                    print(f"Using template {template_hash}. Waiting for preinstalled vLLM to start...")
                     print(f"URL: {api_url}")
 
                     # 2.5 Wait for API to be ready
@@ -180,8 +176,7 @@ class Orchestrator:
                     self.log_group_end()
 
             # 3. Run benchmarks
-            api_key = vllm_api_key if template_hash == "7e24e4e5c2e551d012344a9bf4f141c2" else None
-            tester = LoadTester(api_url, model_name, api_key=api_key)
+            tester = LoadTester(api_url, model_name, api_key=vllm_api_key)
 
             all_results = []
             for c in concurrency_levels:
@@ -227,14 +222,6 @@ class Orchestrator:
                     self.vast.destroy_instance(instance_id)
                     if os.path.exists(".vast_instance_id"):
                         os.remove(".vast_instance_id")
-                elif shutdown_at_exit:
-                    # If we are running on the instance itself, try to self-destruct
-                    print("Shutdown requested. Attempting to identify current instance ID...")
-                    self_id = self.vast.get_current_instance_id()
-                    if self_id:
-                        self.vast.destroy_instance(self_id)
-                    else:
-                        print("Could not identify current instance ID for auto-shutdown.")
             finally:
                 self.log_group_end()
 
@@ -248,7 +235,7 @@ if __name__ == "__main__":
     parser.add_argument("--requests-per-level", type=int, default=10, help="Number of requests per concurrency level")
     parser.add_argument("--wait-timeout", type=int, default=1200, help="Timeout in seconds to wait for API to be ready")
     parser.add_argument("--prompt", type=str, default="Explain quantum physics in one sentence.", help="Prompt to use for benchmarking")
-    parser.add_argument("--template-hash", type=str, default="7e24e4e5c2e551d012344a9bf4f141c2", help="Vast.ai template hash to use for provisioning")
+    parser.add_argument("--template-hash", type=str, default="38b2b68cf896e8582dff6f305a2041b1", help="Vast.ai template hash to use for provisioning")
 
     # Email arguments
     parser.add_argument("--email", type=str, help="Recipient email address for results")
@@ -256,9 +243,6 @@ if __name__ == "__main__":
     parser.add_argument("--smtp-port", type=int, default=int(os.getenv("SMTP_PORT", "587")), help="SMTP server port")
     parser.add_argument("--smtp-user", type=str, default=os.getenv("SMTP_USER"), help="SMTP username")
     parser.add_argument("--smtp-password", type=str, default=os.getenv("SMTP_PASSWORD"), help="SMTP password")
-
-    # Shutdown argument
-    parser.add_argument("--shutdown", action="store_true", help="Auto-shutdown the Vast.ai instance after completion")
 
     args = parser.parse_args()
     orch = Orchestrator()
@@ -286,7 +270,6 @@ if __name__ == "__main__":
                 wait_timeout=args.wait_timeout,
                 prompt=args.prompt,
                 email_config=email_config,
-                shutdown_at_exit=args.shutdown,
                 template_hash=args.template_hash
             ))
         except Exception as e:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -70,13 +70,16 @@ class Orchestrator:
         start_time = time.time()
         async with aiohttp.ClientSession() as session:
             while time.time() - start_time < timeout:
+                elapsed = int(time.time() - start_time)
                 try:
                     async with session.get(f"{url}/v1/models") as response:
                         if response.status == 200:
-                            print("API is ready!")
+                            print(f"API is ready after {elapsed}s!")
                             return True
                 except Exception:
                     pass
+                if elapsed % 30 == 0 and elapsed > 0:
+                    print(f"  ...still waiting ({elapsed}s elapsed)")
                 await asyncio.sleep(10)
         print("Timeout waiting for API to be ready.")
         return False
@@ -102,17 +105,49 @@ class Orchestrator:
         except Exception as e:
             print(f"Failed to send email: {e}")
 
-    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=1200, prompt="Explain quantum physics in one sentence.", email_config=None, template_hash="38b2b68cf896e8582dff6f305a2041b1"):
-        print(f"Starting benchmark suite for {model_name} on {gpu_name}")
+    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=1200, prompt="Explain quantum physics in one sentence.", email_config=None, template_hash="38b2b68cf896e8582dff6f305a2041b1", mode="all"):
+        print(f"Starting benchmark suite for {model_name} on {gpu_name} (Mode: {mode})")
 
         instance_id = None
         vllm_api_key = "vllm-benchmark-token"
 
+        # Load instance ID if it exists (for split-step execution)
+        if os.path.exists(".vast_instance_id"):
+            with open(".vast_instance_id", "r") as f:
+                content = f.read().strip()
+                try:
+                    instance_id = int(content)
+                    print(f"Loaded existing instance ID: {instance_id}")
+                except ValueError:
+                    # In tests we might use string IDs
+                    instance_id = content
+                    print(f"Loaded existing instance ID (string): {instance_id}")
+
+        if mode == "teardown":
+            if not instance_id:
+                print("No instance ID found to teardown.")
+                return
+            self.log_group_start("Teardown")
+            try:
+                self.vast.destroy_instance(instance_id)
+                if os.path.exists(".vast_instance_id"):
+                    os.remove(".vast_instance_id")
+                if os.path.exists(".vast_api_url"):
+                    os.remove(".vast_api_url")
+            finally:
+                self.log_group_end()
+            return
+
         if url:
             api_url = url
             print(f"Using existing endpoint: {api_url}")
-            # Ensure instance_id is None to avoid teardown of existing endpoint if URL is used
-            instance_id = None
+        elif mode == "benchmark":
+            if os.path.exists(".vast_api_url"):
+                with open(".vast_api_url", "r") as f:
+                    api_url = f.read().strip()
+                print(f"Loaded API URL from file: {api_url}")
+            else:
+                raise ValueError("API URL (--url) or .vast_api_url file is required for benchmark mode")
         else:
             if not template_hash:
                 raise ValueError("template_hash is required when provisioning a new instance")
@@ -138,35 +173,38 @@ class Orchestrator:
                 # Persist instance ID for external cleanup (e.g., GitHub Actions cancellation)
                 with open(".vast_instance_id", "w") as f:
                     f.write(str(instance_id))
+
+                # 2. Wait for instance to be ready
+                instance = self.vast.wait_for_ssh(instance_id)
+                if not instance:
+                    raise RuntimeError(f"Instance {instance_id} failed to initialize or become reachable")
+
+                # Determine API URL, prioritizing mapped port 18000
+                ports = instance.get('ports', {})
+                if '18000/tcp' in ports:
+                    api_url = f"http://{ports['18000/tcp'][0]['DirectAddress']}"
+                else:
+                    raise RuntimeError(f"Instance {instance_id} does not have port 18000 mapped. vLLM template requires port 18000.")
+
+                with open(".vast_api_url", "w") as f:
+                    f.write(api_url)
+
+                print(f"Instance ready at {api_url}")
+                print(f"Using template {template_hash}. Waiting for preinstalled vLLM to start...")
+                print(f"URL: {api_url}")
+
+                # 2.5 Wait for API to be ready
+                if not await self.wait_for_api_ready(api_url, timeout=wait_timeout):
+                    raise RuntimeError(f"LLM API at {api_url} never became ready within {wait_timeout} seconds")
             finally:
                 self.log_group_end()
 
+            if mode == "provision":
+                print("Provisioning complete. API is ready.")
+                return
+
         try:
-            if not url:
-                self.log_group_start("Waiting for Instance & API")
-                try:
-                    # 2. Wait for instance to be ready
-                    instance = self.vast.wait_for_ssh(instance_id)
-                    if not instance:
-                        raise RuntimeError(f"Instance {instance_id} failed to initialize or become reachable")
-
-                    # Determine API URL, prioritizing mapped port 18000
-                    ports = instance.get('ports', {})
-                    if '18000/tcp' in ports:
-                        api_url = f"http://{ports['18000/tcp'][0]['DirectAddress']}"
-                    else:
-                        raise RuntimeError(f"Instance {instance_id} does not have port 18000 mapped. vLLM template requires port 18000.")
-
-                    print(f"Instance ready at {api_url}")
-                    print(f"Using template {template_hash}. Waiting for preinstalled vLLM to start...")
-                    print(f"URL: {api_url}")
-
-                    # 2.5 Wait for API to be ready
-                    if not await self.wait_for_api_ready(api_url, timeout=wait_timeout):
-                        raise RuntimeError(f"LLM API at {api_url} never became ready within {wait_timeout} seconds")
-                finally:
-                    self.log_group_end()
-            else:
+            if url or mode == "benchmark":
                 self.log_group_start("Waiting for API")
                 try:
                     # 2.5 Wait for API to be ready
@@ -216,14 +254,17 @@ class Orchestrator:
 
         finally:
             # 5. Teardown
-            self.log_group_start("Teardown")
-            try:
-                if instance_id:
-                    self.vast.destroy_instance(instance_id)
-                    if os.path.exists(".vast_instance_id"):
-                        os.remove(".vast_instance_id")
-            finally:
-                self.log_group_end()
+            if mode == "all":
+                self.log_group_start("Teardown")
+                try:
+                    if instance_id:
+                        self.vast.destroy_instance(instance_id)
+                        if os.path.exists(".vast_instance_id"):
+                            os.remove(".vast_instance_id")
+                        if os.path.exists(".vast_api_url"):
+                            os.remove(".vast_api_url")
+                finally:
+                    self.log_group_end()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Gemma Performance Lab Orchestrator")
@@ -236,6 +277,9 @@ if __name__ == "__main__":
     parser.add_argument("--wait-timeout", type=int, default=1200, help="Timeout in seconds to wait for API to be ready")
     parser.add_argument("--prompt", type=str, default="Explain quantum physics in one sentence.", help="Prompt to use for benchmarking")
     parser.add_argument("--template-hash", type=str, default="38b2b68cf896e8582dff6f305a2041b1", help="Vast.ai template hash to use for provisioning")
+    parser.add_argument("--provision", action="store_true", help="Only provision the instance and wait for API")
+    parser.add_argument("--benchmark", action="store_true", help="Only run benchmarks (requires --url or .vast_api_url)")
+    parser.add_argument("--teardown", action="store_true", help="Only destroy the instance (requires .vast_instance_id)")
 
     # Email arguments
     parser.add_argument("--email", type=str, help="Recipient email address for results")
@@ -260,6 +304,11 @@ if __name__ == "__main__":
                 }
             }
 
+        mode = "all"
+        if args.provision: mode = "provision"
+        elif args.benchmark: mode = "benchmark"
+        elif args.teardown: mode = "teardown"
+
         try:
             asyncio.run(orch.run_suite(
                 args.gpu,
@@ -270,7 +319,8 @@ if __name__ == "__main__":
                 wait_timeout=args.wait_timeout,
                 prompt=args.prompt,
                 email_config=email_config,
-                template_hash=args.template_hash
+                template_hash=args.template_hash,
+                mode=mode
             ))
         except Exception as e:
             orch.log_error(f"Error during benchmark run: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 vastai>=1.0.0
 aiohttp>=3.9.0
+requests>=2.31.0

--- a/tests/test_template_logic.py
+++ b/tests/test_template_logic.py
@@ -19,13 +19,15 @@ class TestTemplateLogic(unittest.TestCase):
 
     @patch("orchestrator.VastManager")
     def test_template_hash_passing(self, MockVastManager):
+        # Set default template hash explicitly to avoid mismatch if default changes
+        template_hash = "my_template_hash"
         mock_vast = MockVastManager.return_value
         mock_vast.find_offers.return_value = [{"id": 123}]
         mock_vast.rent_instance.return_value = "inst_1"
         mock_vast.wait_for_ssh.return_value = {
             "ssh_host": "1.2.3.4",
             "ssh_port": 2222,
-            "ports": {}
+            "ports": {"18000/tcp": [{"DirectAddress": "mapped.host:32768"}]}
         }
 
         async def mock_wait(*args, **kwargs):
@@ -51,14 +53,14 @@ class TestTemplateLogic(unittest.TestCase):
             asyncio.run(self.orchestrator.run_suite(
                 gpu_name="RTX_4090",
                 model_name="gemma",
-                template_hash="my_template_hash",
+                template_hash=template_hash,
                 concurrency_levels=[1],
                 requests_per_level=1
             ))
 
             # Verify rent_instance was called with template_hash
-            expected_env = "-e VLLM_MODEL=gemma -e HF_TOKEN= -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 8000:18000"
-            mock_vast.rent_instance.assert_called_with(123, template_hash="my_template_hash", env=expected_env)
+            expected_env = "-e VLLM_MODEL=gemma -e HF_TOKEN= -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 18000:18000"
+            mock_vast.rent_instance.assert_called_with(123, template_hash=template_hash, env=expected_env)
 
     @patch("orchestrator.VastManager")
     def test_new_template_env_passing(self, MockVastManager):
@@ -68,7 +70,7 @@ class TestTemplateLogic(unittest.TestCase):
         mock_vast.wait_for_ssh.return_value = {
             "ssh_host": "1.2.3.4",
             "ssh_port": 2222,
-            "ports": {"8000/tcp": [{"DirectAddress": "mapped.host:32768"}]}
+            "ports": {"18000/tcp": [{"DirectAddress": "mapped.host:32768"}]}
         }
 
         async def mock_wait(*args, **kwargs):
@@ -91,14 +93,14 @@ class TestTemplateLogic(unittest.TestCase):
                 asyncio.run(self.orchestrator.run_suite(
                     gpu_name="RTX_4090",
                     model_name="gemma-test",
-                    template_hash="7e24e4e5c2e551d012344a9bf4f141c2",
+                    template_hash="38b2b68cf896e8582dff6f305a2041b1",
                     concurrency_levels=[1],
                     requests_per_level=1
                 ))
 
             # Verify rent_instance was called with the correct env string
-            expected_env = "-e VLLM_MODEL=gemma-test -e HF_TOKEN=test_hf_token -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 8000:18000"
-            mock_vast.rent_instance.assert_called_with(123, template_hash="7e24e4e5c2e551d012344a9bf4f141c2", env=expected_env)
+            expected_env = "-e VLLM_MODEL=gemma-test -e HF_TOKEN=test_hf_token -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 18000:18000"
+            mock_vast.rent_instance.assert_called_with(123, template_hash="38b2b68cf896e8582dff6f305a2041b1", env=expected_env)
 
             # Verify LoadTester was initialized with the API key
             MockLoadTester.assert_called_with("http://mapped.host:32768", "gemma-test", api_key="vllm-benchmark-token")
@@ -109,12 +111,12 @@ class TestTemplateLogic(unittest.TestCase):
         mock_vast.find_offers.return_value = [{"id": 123}]
         mock_vast.rent_instance.return_value = "inst_1"
 
-        # Case 1: Port 8000 is mapped
+        # Case 1: Port 18000 is mapped
         mock_vast.wait_for_ssh.return_value = {
             "ssh_host": "1.2.3.4",
             "ssh_port": 2222,
             "ports": {
-                "8000/tcp": [{"DirectAddress": "mapped.host:32768"}]
+                "18000/tcp": [{"DirectAddress": "mapped.host:32768"}]
             }
         }
 
@@ -136,31 +138,22 @@ class TestTemplateLogic(unittest.TestCase):
             ))
 
             # Check if LoadTester was initialized with the mapped URL
-            MockLoadTester.assert_called_with("http://mapped.host:32768", "gemma", api_key=None)
+            MockLoadTester.assert_called_with("http://mapped.host:32768", "gemma", api_key="vllm-benchmark-token")
 
     @patch("orchestrator.VastManager")
-    def test_api_url_construction_fallback(self, MockVastManager):
+    def test_api_url_construction_failure_if_no_port_18000(self, MockVastManager):
         mock_vast = MockVastManager.return_value
         mock_vast.find_offers.return_value = [{"id": 123}]
         mock_vast.rent_instance.return_value = "inst_1"
 
-        # Case 2: Port 8000 is NOT mapped
+        # Case 2: Port 18000 is NOT mapped
         mock_vast.wait_for_ssh.return_value = {
             "ssh_host": "1.2.3.4",
             "ssh_port": 2222,
             "ports": {}
         }
 
-        async def mock_wait(*args, **kwargs):
-            return True
-        self.orchestrator.wait_for_api_ready = mock_wait
-
-        with patch("orchestrator.LoadTester") as MockLoadTester:
-            mock_tester = MockLoadTester.return_value
-            async def mock_run_bench(*args, **kwargs):
-                return {"total_tps": 10.0}
-            mock_tester.run_benchmark = mock_run_bench
-
+        with self.assertRaises(RuntimeError) as cm:
             asyncio.run(self.orchestrator.run_suite(
                 gpu_name="RTX_4090",
                 model_name="gemma",
@@ -168,8 +161,7 @@ class TestTemplateLogic(unittest.TestCase):
                 requests_per_level=1
             ))
 
-            # Check if LoadTester was initialized with the SSH URL fallback
-            MockLoadTester.assert_called_with("http://1.2.3.4:2222", "gemma", api_key=None)
+        self.assertIn("does not have port 18000 mapped", str(cm.exception))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This refactor transitions the benchmarking framework to a local-orchestrator model. The `orchestrator.py` script now runs on the local machine (or GitHub Actions runner) and manages the full lifecycle of a remote Vast.ai instance provisioned via an optimized vLLM template.

Key changes:
- `orchestrator.py`: Enforces `template_hash` for new instances, removes `shutdown_at_exit` and `get_current_instance_id`, and standardizes port 18000 usage.
- `.github/workflows/vast_ai_benchmark.yml`: Optimized for running the orchestrator on the runner.
- `HOWTO.md`: Rewritten to focus on the GitHub Actions workflow as the primary usage method.
- `tests/`: Unit tests updated to verify the new port mapping and template logic.
- `requirements.txt`: Added `requests` as a direct dependency.

Fixes #50

---
*PR created automatically by Jules for task [11202305873417359062](https://jules.google.com/task/11202305873417359062) started by @chatelao*