### PR TITLE
Standardize Port Mappings for Vast.ai Benchmarking

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -64,4 +64,9 @@ python tests/micro_runtime_test.py
 This framework relies on optimized Vast.ai templates. The default template (`38b2b68cf896e8582dff6f305a2041b1`) is pre-configured with:
 - **vLLM Engine:** For high-throughput inference.
 - **Auto-Config:** Uses environment variables (`VLLM_MODEL`, `HF_TOKEN`, `OPEN_BUTTON_TOKEN`) for zero-touch setup.
-- **Port Mapping:** Exposes vLLM on port 18000 for the orchestrator to connect.
+- **Port Mapping:** Exposes services on standard ports:
+    - Instance Portal: 1111 (internal 11111)
+    - Model UI: 7860 (internal 17860)
+    - vLLM API: 8000 (internal 18000)
+    - Ray Dashboard: 8265 (internal 28265)
+    - Jupyter: 8080 (internal 18080)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ https://huggingface.co/google/gemma-2-9b-it
 docker run --gpus all \
            -v ~/.cache/huggingface:/root/.cache/huggingface \
            -e HF_TOKEN=<your_token> \
-           -p 8000:8000 vllm/vllm-openai:v0.4.0 \
+           -p 1111:11111 -p 7860:17860 -p 8000:18000 -p 8265:28265 -p 8080:18080 \
+           vllm/vllm-openai:v0.4.0 \
            --model google/gemma-2-9b-it \
+           --port 18000 \
            --max-model-len 512 \
            --block-size 16 \
            --dtype float \

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -171,7 +171,7 @@ class Orchestrator:
 
                 hf_token = os.getenv("HF_TOKEN", "")
                 vllm_args = "--dtype auto --enforce-eager --max-model-len 512 --block-size 16"
-                env_vars = f"-e VLLM_MODEL={model_name} -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 18000:18000"
+                env_vars = f"-e VLLM_MODEL={model_name} -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 1111:11111 -p 7860:17860 -p 8000:18000 -p 8265:28265 -p 8080:18080"
 
                 # Select the best offer (lowest price per hour)
                 offer_id = offers[0]['id']
@@ -188,10 +188,10 @@ class Orchestrator:
                 if not instance:
                     raise RuntimeError(f"Instance {instance_id} failed to initialize or become reachable")
 
-                # Determine API URL, prioritizing mapped port 18000
+                # Determine API URL, prioritizing mapped port 18000 (Internal) / 8000 (External)
                 # We may need to wait a few more seconds for port mappings to propagate
                 api_url = None
-                print(f"Waiting for port 18000 mapping for instance {instance_id}...")
+                print(f"Waiting for vLLM API (port 18000->8000) mapping for instance {instance_id}...")
                 port_retry_start = time.time()
                 while time.time() - port_retry_start < 60: # Wait up to 60 seconds for port mapping
                     instances = self.vast.sdk.show_instances()

--- a/tests/test_template_logic.py
+++ b/tests/test_template_logic.py
@@ -61,7 +61,7 @@ class TestTemplateLogic(unittest.TestCase):
 
             # Verify rent_instance was called with template_hash
             vllm_args = "--dtype auto --enforce-eager --max-model-len 512 --block-size 16"
-            expected_env = f"-e VLLM_MODEL=gemma -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN= -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 18000:18000"
+            expected_env = f"-e VLLM_MODEL=gemma -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN= -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 1111:11111 -p 7860:17860 -p 8000:18000 -p 8265:28265 -p 8080:18080"
             mock_vast.rent_instance.assert_called_with(123, template_hash=template_hash, env=expected_env)
 
     @patch("orchestrator.VastManager")
@@ -103,7 +103,7 @@ class TestTemplateLogic(unittest.TestCase):
 
             # Verify rent_instance was called with the correct env string
             vllm_args = "--dtype auto --enforce-eager --max-model-len 512 --block-size 16"
-            expected_env = f"-e VLLM_MODEL=gemma-test -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN=test_hf_token -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 18000:18000"
+            expected_env = f"-e VLLM_MODEL=gemma-test -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN=test_hf_token -e OPEN_BUTTON_TOKEN=vllm-benchmark-token -p 1111:11111 -p 7860:17860 -p 8000:18000 -p 8265:28265 -p 8080:18080"
             mock_vast.rent_instance.assert_called_with(123, template_hash="38b2b68cf896e8582dff6f305a2041b1", env=expected_env)
 
             # Verify LoadTester was initialized with the API key


### PR DESCRIPTION
This change standardizes the port mappings used when provisioning Vast.ai instances for LLM benchmarking. It ensures that the vLLM API is exposed on the standard external port 8000 while maintaining the internal port 18000 as required by the templates. Documentation and tests have been updated to remain consistent with these changes.

Fixes #56

---
*PR created automatically by Jules for task [17781304549653361401](https://jules.google.com/task/17781304549653361401) started by @chatelao*