### PR TITLE
Separate LLM engine startup and benchmark suite execution into modular scripts

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -58,26 +58,22 @@ jobs:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
-        python orchestrator.py \
+        python provision.py \
           --gpu "${{ github.event.inputs.gpu }}" \
           --model "${{ github.event.inputs.model }}" \
-          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }} \
-          --provision \
-          --run
+          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }}
 
     - name: Run Benchmark Suite
       env:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
-        python orchestrator.py \
+        python benchmark.py \
           --gpu "${{ github.event.inputs.gpu }}" \
           --model "${{ github.event.inputs.model }}" \
           --concurrency-levels ${{ github.event.inputs.concurrency_levels }} \
           --requests-per-level ${{ github.event.inputs.requests_per_level }} \
-          --prompt "${{ github.event.inputs.prompt }}" \
-          --benchmark \
-          --run
+          --prompt "${{ github.event.inputs.prompt }}"
 
     - name: Upload results
       uses: actions/upload-artifact@v4
@@ -91,4 +87,4 @@ jobs:
       env:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
       run: |
-        python orchestrator.py --teardown --run
+        python teardown.py

--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -30,15 +30,14 @@ jobs:
         # Wait for mock server to be ready
         timeout 30 bash -c 'until curl -sf http://localhost:8000/v1/models; do sleep 1; done' || (echo "Mock server failed to start" && exit 1)
 
-    - name: Run Orchestrator against mock server
+    - name: Run benchmark against mock server
       run: |
-        python orchestrator.py \
+        python benchmark.py \
           --url http://localhost:8000 \
           --model tiny-model \
           --gpu mock-gpu \
           --concurrency-levels 1 2 \
-          --requests-per-level 5 \
-          --run
+          --requests-per-level 5
 
     - name: Check benchmark results
       run: |

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -42,13 +42,15 @@ export HF_TOKEN=your_hf_token
 The orchestrator will provision an instance using the optimized vLLM template, run the benchmarks, and then destroy the instance.
 
 ```bash
-python3 orchestrator.py --gpu "RTX_4090" --model "google/gemma-2-9b-it" --run
+python3 provision.py --gpu "RTX_4090" --model "google/gemma-2-9b-it"
+python3 benchmark.py --gpu "RTX_4090" --model "google/gemma-2-9b-it"
+python3 teardown.py
 ```
 
-The orchestrator also supports granular execution modes, which are used by the GitHub Actions workflow:
-- `--provision`: Just rent the instance and wait for the API to be ready.
-- `--benchmark`: Run the benchmark suite against an already provisioned instance.
-- `--teardown`: Destroy the provisioned instance.
+The framework provides granular execution scripts, which are used by the GitHub Actions workflow:
+- `provision.py`: Rent the instance and wait for the API to be ready.
+- `benchmark.py`: Run the benchmark suite against an already provisioned instance.
+- `teardown.py`: Destroy the provisioned instance.
 
 ## Local Verification (No GPU required)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ This framework automates the benchmarking of Gemma models (and other LLMs) acros
 - `CONCEPT.md`: Detailed architecture and objectives.
 - `infra/vast_manager.py`: Infrastructure management logic.
 - `bench/load_tester.py`: Load testing and metrics collection.
-- `orchestrator.py`: End-to-end automation script.
+- `orchestrator.py`: Core logic for provisioning and benchmarking.
+- `provision.py`: CLI for renting Vast.ai instances.
+- `benchmark.py`: CLI for running the benchmark suite.
+- `teardown.py`: CLI for destroying instances.
 - `requirements.txt`: Python dependencies.
 
 ## Getting Started
@@ -67,7 +70,9 @@ python3 bench/load_tester.py --url http://<instance-ip>:<port> --model gemma-2-9
 
 #### 3. Run the Full Orchestrator
 ```bash
-python3 orchestrator.py --gpu "RTX_4090" --model "gemma-2-9b"
+python3 provision.py --gpu "RTX_4090" --model "google/gemma-2-9b-it"
+python3 benchmark.py --gpu "RTX_4090" --model "google/gemma-2-9b-it"
+python3 teardown.py
 ```
 
 ## Metrics Defined

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,60 @@
+import asyncio
+import argparse
+import sys
+import os
+from orchestrator import Orchestrator
+
+async def main():
+    parser = argparse.ArgumentParser(description="Run LLM Benchmark Suite")
+    parser.add_argument("--gpu", type=str, default="RTX_4090", help="GPU model being tested")
+    parser.add_argument("--model", type=str, required=True, help="Model name being tested")
+    parser.add_argument("--url", type=str, help="API endpoint URL (defaults to .vast_api_url content)")
+    parser.add_argument("--concurrency-levels", type=int, nargs="+", default=[1, 4, 16], help="Concurrency levels")
+    parser.add_argument("--requests-per-level", type=int, default=10, help="Requests per level")
+    parser.add_argument("--prompt", type=str, default="Explain quantum physics in one sentence.", help="Benchmark prompt")
+    parser.add_argument("--wait-timeout", type=int, default=1200, help="Wait timeout in seconds")
+
+    # Email arguments
+    parser.add_argument("--email", type=str, help="Recipient email address")
+    parser.add_argument("--smtp-host", type=str, default=os.getenv("SMTP_HOST"), help="SMTP host")
+    parser.add_argument("--smtp-port", type=int, default=int(os.getenv("SMTP_PORT", "587")), help="SMTP port")
+    parser.add_argument("--smtp-user", type=str, default=os.getenv("SMTP_USER"), help="SMTP user")
+    parser.add_argument("--smtp-password", type=str, default=os.getenv("SMTP_PASSWORD"), help="SMTP password")
+
+    args = parser.parse_args()
+    orch = Orchestrator()
+
+    api_url = args.url or orch.load_api_url()
+    if not api_url:
+        orch.log_error("API URL not provided and .vast_api_url not found.")
+        sys.exit(1)
+
+    email_config = None
+    if args.email:
+        email_config = {
+            'to': args.email,
+            'smtp': {
+                'host': args.smtp_host,
+                'port': args.smtp_port,
+                'user': args.smtp_user,
+                'password': args.smtp_password
+            }
+        }
+
+    try:
+        await orch.run_benchmark_suite(
+            gpu_name=args.gpu,
+            model_name=args.model,
+            api_url=api_url,
+            concurrency_levels=args.concurrency_levels,
+            requests_per_level=args.requests_per_level,
+            prompt=args.prompt,
+            email_config=email_config,
+            wait_timeout=args.wait_timeout
+        )
+    except Exception as e:
+        orch.log_error(f"Benchmarking failed: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -113,178 +113,161 @@ class Orchestrator:
         except Exception as e:
             print(f"Failed to send email: {e}")
 
-    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=1200, prompt="Explain quantum physics in one sentence.", email_config=None, template_hash="38b2b68cf896e8582dff6f305a2041b1", mode="all"):
-        print(f"Starting benchmark suite for {model_name} on {gpu_name} (Mode: {mode})")
-
-        instance_id = None
-        vllm_api_key = "vllm-benchmark-token"
-
-        # Load instance ID if it exists (for split-step execution)
+    def load_instance_id(self):
         if os.path.exists(".vast_instance_id"):
             with open(".vast_instance_id", "r") as f:
                 content = f.read().strip()
                 try:
-                    instance_id = int(content)
-                    print(f"Loaded existing instance ID: {instance_id}")
+                    return int(content)
                 except ValueError:
-                    # In tests we might use string IDs
-                    instance_id = content
-                    print(f"Loaded existing instance ID (string): {instance_id}")
+                    return content
+        return None
 
-        if mode == "teardown":
+    def load_api_url(self):
+        if os.path.exists(".vast_api_url"):
+            with open(".vast_api_url", "r") as f:
+                return f.read().strip()
+        return None
+
+    async def provision_instance(self, gpu_name, model_name, template_hash="38b2b68cf896e8582dff6f305a2041b1", wait_timeout=1200):
+        self.log_group_start("Instance Provisioning")
+        try:
+            # 1. Find and rent instance
+            offers = self.vast.find_offers(gpu_name)
+            if not offers:
+                self.log_error(f"No offers found for {gpu_name} (or API error occurred)")
+                raise RuntimeError(f"Could not find any offers for {gpu_name}")
+
+            vllm_api_key = "vllm-benchmark-token"
+            hf_token = os.getenv("HF_TOKEN", "")
+            vllm_args = "--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000"
+            env_vars = f"-e VLLM_MODEL={model_name} -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 1111:1111 -p 7860:7860 -p 8000:8000 -p 8265:8265 -p 8080:8080"
+
+            offer_id = offers[0]['id']
+            instance_id = self.vast.rent_instance(offer_id, template_hash=template_hash, env=env_vars)
             if not instance_id:
-                print("No instance ID found to teardown.")
-                return
-            self.log_group_start("Teardown")
+                raise RuntimeError(f"Failed to rent instance using offer {offer_id}")
+
+            with open(".vast_instance_id", "w") as f:
+                f.write(str(instance_id))
+
+            # 2. Wait for instance to be ready
+            instance = self.vast.wait_for_ssh(instance_id)
+            if not instance:
+                raise RuntimeError(f"Instance {instance_id} failed to initialize or become reachable")
+
+            host = instance.get('public_ipaddr', instance.get('ssh_host'))
+            port = 8000
+            ports = instance.get('ports', {})
+            for port_key, mappings in ports.items():
+                if port_key.startswith('8000'):
+                    if isinstance(mappings, list) and len(mappings) > 0:
+                        mapping = mappings[0]
+                        if isinstance(mapping, dict):
+                            port = mapping.get('HostPort', port)
+                    elif isinstance(mappings, (str, int)):
+                        port = mappings
+                    break
+
+            api_url = f"http://{host}:{port}"
+            with open(".vast_api_url", "w") as f:
+                f.write(api_url)
+
+            print(f"Instance ready at {api_url}")
+            print(f"Using template {template_hash}. Waiting for preinstalled vLLM to start...")
+
+            if not await self.wait_for_api_ready(api_url, api_key=vllm_api_key, timeout=wait_timeout):
+                raise RuntimeError(f"LLM API at {api_url} never became ready within {wait_timeout} seconds")
+
+            return api_url
+        finally:
+            self.log_group_end()
+
+    async def run_benchmark_suite(self, gpu_name, model_name, api_url, concurrency_levels=[1, 4, 16], requests_per_level=10, prompt="Explain quantum physics in one sentence.", email_config=None, wait_timeout=1200):
+        vllm_api_key = "vllm-benchmark-token"
+
+        self.log_group_start("Waiting for API")
+        try:
+            if not await self.wait_for_api_ready(api_url, api_key=vllm_api_key, timeout=wait_timeout):
+                raise RuntimeError(f"LLM API at {api_url} never became ready within {wait_timeout} seconds")
+        finally:
+            self.log_group_end()
+
+        tester = LoadTester(api_url, model_name, api_key=vllm_api_key)
+        all_results = []
+        for c in concurrency_levels:
+            self.log_group_start(f"Benchmark: Concurrency {c}")
             try:
-                self.vast.destroy_instance(instance_id)
-                if os.path.exists(".vast_instance_id"):
-                    os.remove(".vast_instance_id")
-                if os.path.exists(".vast_api_url"):
-                    os.remove(".vast_api_url")
+                print(f"Running benchmark with concurrency: {c}")
+                try:
+                    result = await tester.run_benchmark(c, requests_per_level, prompt=prompt)
+                    if result:
+                        result["gpu"] = gpu_name
+                        result["model"] = model_name
+                        all_results.append(result)
+                        print(f"Result: {result['total_tps']:.2f} tokens/s")
+                    else:
+                        print(f"Benchmark failed for concurrency {c} (Is the server running?)")
+                except Exception as e:
+                    self.log_error(f"Error during benchmark: {e}")
             finally:
                 self.log_group_end()
+
+        if all_results:
+            report_file = f"benchmark_{gpu_name.replace(' ', '_')}_{int(time.time())}.json"
+            with open(report_file, "w") as f:
+                json.dump(all_results, f, indent=2)
+            print(f"Suite complete. Results saved to {report_file}")
+            self.write_step_summary(all_results)
+            if email_config and email_config.get('to'):
+                self.send_email_report(all_results, email_config['to'], email_config['smtp'])
+        else:
+            print("No results collected.")
+
+        return all_results
+
+    def teardown_instance(self):
+        instance_id = self.load_instance_id()
+        if not instance_id:
+            print("No instance ID found to teardown.")
             return
 
-        if url:
-            api_url = url
-            print(f"Using existing endpoint: {api_url}")
-        elif mode == "benchmark":
+        self.log_group_start("Teardown")
+        try:
+            self.vast.destroy_instance(instance_id)
+            if os.path.exists(".vast_instance_id"):
+                os.remove(".vast_instance_id")
             if os.path.exists(".vast_api_url"):
-                with open(".vast_api_url", "r") as f:
-                    api_url = f.read().strip()
-                print(f"Loaded API URL from file: {api_url}")
+                os.remove(".vast_api_url")
+            print(f"Instance {instance_id} destroyed.")
+        finally:
+            self.log_group_end()
+
+    async def run_suite(self, gpu_name, model_name, url=None, concurrency_levels=[1, 4, 16], requests_per_level=10, wait_timeout=1200, prompt="Explain quantum physics in one sentence.", email_config=None, template_hash="38b2b68cf896e8582dff6f305a2041b1", mode="all"):
+        print(f"Starting benchmark suite for {model_name} on {gpu_name} (Mode: {mode})")
+
+        if mode == "teardown":
+            self.teardown_instance()
+            return
+
+        api_url = url
+        if not api_url:
+            if mode == "benchmark":
+                api_url = self.load_api_url()
+                if not api_url:
+                    raise ValueError("API URL (--url) or .vast_api_url file is required for benchmark mode")
             else:
-                raise ValueError("API URL (--url) or .vast_api_url file is required for benchmark mode")
-        else:
-            if not template_hash:
-                raise ValueError("template_hash is required when provisioning a new instance")
+                api_url = await self.provision_instance(gpu_name, model_name, template_hash, wait_timeout)
 
-            self.log_group_start("Instance Provisioning")
-            try:
-                # 1. Find and rent instance
-                offers = self.vast.find_offers(gpu_name)
-                if not offers:
-                    self.log_error(f"No offers found for {gpu_name} (or API error occurred)")
-                    # Force exit with error code if we can't find offers and were supposed to run
-                    raise RuntimeError(f"Could not find any offers for {gpu_name}")
-
-                hf_token = os.getenv("HF_TOKEN", "")
-                vllm_args = "--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000"
-                env_vars = f"-e VLLM_MODEL={model_name} -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 1111:1111 -p 7860:7860 -p 8000:8000 -p 8265:8265 -p 8080:8080"
-
-                # Select the best offer (lowest price per hour)
-                offer_id = offers[0]['id']
-                instance_id = self.vast.rent_instance(offer_id, template_hash=template_hash, env=env_vars)
-                if not instance_id:
-                    raise RuntimeError(f"Failed to rent instance using offer {offer_id}")
-
-                # Persist instance ID for external cleanup (e.g., GitHub Actions cancellation)
-                with open(".vast_instance_id", "w") as f:
-                    f.write(str(instance_id))
-
-                # 2. Wait for instance to be ready
-                instance = self.vast.wait_for_ssh(instance_id)
-                if not instance:
-                    raise RuntimeError(f"Instance {instance_id} failed to initialize or become reachable")
-
-                # Resolve external API URL using public IP and port mappings
-                host = instance.get('public_ipaddr', instance.get('ssh_host'))
-                port = 8000
-                ports = instance.get('ports', {})
-                for port_key, mappings in ports.items():
-                    if port_key.startswith('8000'):
-                        if isinstance(mappings, list) and len(mappings) > 0:
-                            # Handle standard SDK/Docker port mapping structure
-                            mapping = mappings[0]
-                            if isinstance(mapping, dict):
-                                port = mapping.get('HostPort', port)
-                        elif isinstance(mappings, (str, int)):
-                            # Handle potential simplified mapping
-                            port = mappings
-                        break
-
-                api_url = f"http://{host}:{port}"
-
-                with open(".vast_api_url", "w") as f:
-                    f.write(api_url)
-
-                print(f"Instance ready at {api_url}")
-                print(f"Using template {template_hash}. Waiting for preinstalled vLLM to start...")
-                print(f"URL: {api_url}")
-
-                # 2.5 Wait for API to be ready
-                if not await self.wait_for_api_ready(api_url, api_key=vllm_api_key, timeout=wait_timeout):
-                    raise RuntimeError(f"LLM API at {api_url} never became ready within {wait_timeout} seconds")
-            finally:
-                self.log_group_end()
-
-            if mode == "provision":
-                print("Provisioning complete. API is ready.")
-                return
+        if mode == "provision":
+            print("Provisioning complete. API is ready.")
+            return
 
         try:
-            if url or mode == "benchmark":
-                self.log_group_start("Waiting for API")
-                try:
-                    # 2.5 Wait for API to be ready
-                    if not await self.wait_for_api_ready(api_url, api_key=vllm_api_key, timeout=wait_timeout):
-                        raise RuntimeError(f"LLM API at {api_url} never became ready within {wait_timeout} seconds")
-                finally:
-                    self.log_group_end()
-
-            # 3. Run benchmarks
-            tester = LoadTester(api_url, model_name, api_key=vllm_api_key)
-
-            all_results = []
-            for c in concurrency_levels:
-                self.log_group_start(f"Benchmark: Concurrency {c}")
-                try:
-                    print(f"Running benchmark with concurrency: {c}")
-                    # We attempt to run the actual load tester
-                    try:
-                        result = await tester.run_benchmark(c, requests_per_level, prompt=prompt)
-                        if result:
-                            result["gpu"] = gpu_name
-                            result["model"] = model_name
-                            all_results.append(result)
-                            print(f"Result: {result['total_tps']:.2f} tokens/s")
-                        else:
-                            print(f"Benchmark failed for concurrency {c} (Is the server running?)")
-                    except Exception as e:
-                        self.log_error(f"Error during benchmark: {e}")
-                finally:
-                    self.log_group_end()
-
-            # 4. Save results
-            if all_results:
-                report_file = f"benchmark_{gpu_name.replace(' ', '_')}_{int(time.time())}.json"
-                with open(report_file, "w") as f:
-                    json.dump(all_results, f, indent=2)
-                print(f"Suite complete. Results saved to {report_file}")
-
-                # 4.2 Write GitHub Step Summary
-                self.write_step_summary(all_results)
-
-                # 4.5 Send email if configured
-                if email_config and email_config.get('to'):
-                    self.send_email_report(all_results, email_config['to'], email_config['smtp'])
-            else:
-                print("No results collected.")
-
+            await self.run_benchmark_suite(gpu_name, model_name, api_url, concurrency_levels, requests_per_level, prompt, email_config, wait_timeout)
         finally:
-            # 5. Teardown
             if mode == "all":
-                self.log_group_start("Teardown")
-                try:
-                    if instance_id:
-                        self.vast.destroy_instance(instance_id)
-                        if os.path.exists(".vast_instance_id"):
-                            os.remove(".vast_instance_id")
-                        if os.path.exists(".vast_api_url"):
-                            os.remove(".vast_api_url")
-                finally:
-                    self.log_group_end()
+                self.teardown_instance()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Gemma Performance Lab Orchestrator")

--- a/provision.py
+++ b/provision.py
@@ -1,0 +1,29 @@
+import asyncio
+import argparse
+import sys
+from orchestrator import Orchestrator
+
+async def main():
+    parser = argparse.ArgumentParser(description="Provision Vast.ai Instance for LLM Benchmarking")
+    parser.add_argument("--gpu", type=str, default="RTX_4090", help="GPU model to test")
+    parser.add_argument("--model", type=str, required=True, help="Model name")
+    parser.add_argument("--template-hash", type=str, default="38b2b68cf896e8582dff6f305a2041b1", help="Vast.ai template hash")
+    parser.add_argument("--wait-timeout", type=int, default=1200, help="Wait timeout in seconds")
+
+    args = parser.parse_args()
+    orch = Orchestrator()
+
+    try:
+        api_url = await orch.provision_instance(
+            gpu_name=args.gpu,
+            model_name=args.model,
+            template_hash=args.template_hash,
+            wait_timeout=args.wait_timeout
+        )
+        print(f"Provisioning successful. API URL: {api_url}")
+    except Exception as e:
+        orch.log_error(f"Provisioning failed: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/teardown.py
+++ b/teardown.py
@@ -1,0 +1,23 @@
+import argparse
+from orchestrator import Orchestrator
+
+def main():
+    parser = argparse.ArgumentParser(description="Teardown Vast.ai Instance")
+    # Adding arguments just in case, though current Orchestrator.teardown_instance()
+    # uses the persisted .vast_instance_id file.
+    parser.add_argument("--instance-id", type=str, help="Specific instance ID to destroy")
+
+    args = parser.parse_args()
+    orch = Orchestrator()
+
+    if args.instance_id:
+        # If an instance ID is provided, we can manually destroy it.
+        # Orchestrator doesn't have a direct method for this yet that doesn't load from file,
+        # but we can easily call the manager.
+        print(f"Destroying instance {args.instance_id}...")
+        orch.vast.destroy_instance(args.instance_id)
+    else:
+        orch.teardown_instance()
+
+if __name__ == "__main__":
+    main()

--- a/tests/micro_runtime_test.py
+++ b/tests/micro_runtime_test.py
@@ -62,16 +62,15 @@ def run_test():
                 print(stdout)
             sys.exit(1)
 
-        # Run Orchestrator
-        print("Running Orchestrator...")
+        # Run benchmark
+        print("Running benchmark script...")
         orch_command = [
-            sys.executable, "orchestrator.py",
+            sys.executable, "benchmark.py",
             "--url", "http://localhost:8000",
             "--model", "facebook/opt-125m",
             "--gpu", "micro-test-cpu",
             "--concurrency-levels", "1",
-            "--requests-per-level", "2",
-            "--run"
+            "--requests-per-level", "2"
         ]
 
         result = subprocess.run(orch_command, capture_output=True, text=True)


### PR DESCRIPTION
This change refactors the LLM benchmarking framework to support more granular control over the benchmark lifecycle. By separating provisioning, benchmarking, and teardown into distinct scripts (`provision.py`, `benchmark.py`, `teardown.py`), the GitHub Actions workflow can now execute these phases as separate steps, improving logging and error isolation. The core logic remains in `orchestrator.py`, which has been refactored for modularity while preserving its original CLI interface. All workflows, tests, and documentation have been updated to align with this new structure.

Fixes #62

---
*PR created automatically by Jules for task [4369783980031555833](https://jules.google.com/task/4369783980031555833) started by @chatelao*