### PR TITLE
Resolve and log external port from Vast.ai REST API

### DIFF
--- a/infra/vast_manager.py
+++ b/infra/vast_manager.py
@@ -95,6 +95,29 @@ class VastManager:
             print(f"Unexpected error destroying instance {instance_id}: {e}")
             return None
 
+    def get_instance_details(self, instance_id):
+        """Fetch current details for a specific instance using the REST API."""
+        url = f"https://console.vast.ai/api/v0/instances/{instance_id}/"
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        try:
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+
+            # The API might return {"instances": [...]}, {"instance": {...}}, or just the instance object
+            if isinstance(data, dict):
+                if "instances" in data:
+                    instances = data["instances"]
+                    if isinstance(instances, list):
+                        return next((i for i in instances if str(i.get('id')) == str(instance_id)), None)
+                    return instances
+                if "instance" in data:
+                    return data["instance"]
+            return data
+        except Exception as e:
+            print(f"Error fetching instance details for {instance_id}: {e}")
+            return None
+
     def get_current_instance_id(self):
         """Identifies the current Vast.ai instance ID by matching its public IP."""
         try:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -156,18 +156,23 @@ class Orchestrator:
             if not instance:
                 raise RuntimeError(f"Instance {instance_id} failed to initialize or become reachable")
 
-            host = instance.get('public_ipaddr', instance.get('ssh_host'))
+            # 3. Refresh instance details to get mapped ports from the API
+            details = self.vast.get_instance_details(instance_id) or instance
+            host = details.get('public_ipaddr', details.get('ssh_host'))
             port = 8000
-            ports = instance.get('ports', {})
-            for port_key, mappings in ports.items():
-                if port_key.startswith('8000'):
-                    if isinstance(mappings, list) and len(mappings) > 0:
-                        mapping = mappings[0]
-                        if isinstance(mapping, dict):
-                            port = mapping.get('HostPort', port)
-                    elif isinstance(mappings, (str, int)):
-                        port = mappings
-                    break
+            ports = details.get('ports', {})
+            if isinstance(ports, dict):
+                for port_key, mappings in ports.items():
+                    if port_key.startswith('8000'):
+                        if isinstance(mappings, list) and len(mappings) > 0:
+                            mapping = mappings[0]
+                            if isinstance(mapping, dict):
+                                port = mapping.get('HostPort', port)
+                        elif isinstance(mappings, (str, int)):
+                            port = mappings
+                        break
+
+            self.log_notice(f"LLM External Port: {port}")
 
             api_url = f"http://{host}:{port}"
             with open(".vast_api_url", "w") as f:

--- a/tests/test_template_logic.py
+++ b/tests/test_template_logic.py
@@ -83,6 +83,13 @@ class TestTemplateLogic(unittest.TestCase):
         async def mock_wait(*args, **kwargs):
             return True
         self.orchestrator.wait_for_api_ready = mock_wait
+        # Mock get_instance_details to return a realistic response with external port
+        mock_vast.get_instance_details.return_value = {
+            "public_ipaddr": "1.2.3.4",
+            "ports": {
+                "8000/tcp": [{"HostPort": 8888}]
+            }
+        }
 
         with patch("orchestrator.LoadTester") as MockLoadTester:
             mock_tester = MockLoadTester.return_value
@@ -97,7 +104,8 @@ class TestTemplateLogic(unittest.TestCase):
                 requests_per_level=1
             ))
 
-            MockLoadTester.assert_called_with("http://1.2.3.4:8000", "gemma-test", api_key="vllm-benchmark-token")
+            # Verify LoadTester was initialized with the API key and the correctly resolved URL from get_instance_details
+            MockLoadTester.assert_called_with("http://1.2.3.4:8888", "gemma-test", api_key="vllm-benchmark-token")
 
     @patch("orchestrator.VastManager")
     @patch("orchestrator.time.sleep")
@@ -117,6 +125,13 @@ class TestTemplateLogic(unittest.TestCase):
         async def mock_wait(*args, **kwargs):
             return True
         self.orchestrator.wait_for_api_ready = mock_wait
+        # Mock get_instance_details to return a realistic response with external port
+        mock_vast.get_instance_details.return_value = {
+            "public_ipaddr": "1.2.3.4",
+            "ports": {
+                "8000/tcp": [{"HostPort": 12345}]
+            }
+        }
 
         with patch("orchestrator.LoadTester") as MockLoadTester:
             mock_tester = MockLoadTester.return_value


### PR DESCRIPTION
This change improves the reliability of port discovery when provisioning Vast.ai instances for LLM benchmarking. It adds a new method to the `VastManager` that queries the Vast.ai REST API directly (at `https://console.vast.ai/api/v0/instances/{instance_id}/`) to retrieve the current instance state, including dynamic port mappings.

The `Orchestrator` then uses this data to extract the 5-digit external port mapped to the internal vLLM port (8000) and logs it using a GitHub Actions notice. This ensures that the correct external URL is used for benchmarking and is visible in the CI logs.

The solution is robust, handling various possible response formats from the Vast API (e.g., wrapped in 'instance' or 'instances' keys) and implementing type-safe ID comparisons. Testing has been updated to cover these new code paths.

Fixes #66

---
*PR created automatically by Jules for task [3748666172893395506](https://jules.google.com/task/3748666172893395506) started by @chatelao*