### PR TITLE
Split End-to-End Benchmark into Discrete Workflow Steps

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -53,18 +53,31 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Run End-to-End Benchmark
+    - name: Provision Vast.ai Instance
       env:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
-        python main.py \
+        python provision.py \
+          --gpu "${{ github.event.inputs.gpu }}" \
+          --model "${{ github.event.inputs.model }}" \
+          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }}
+
+    - name: Run Benchmark
+      run: |
+        python benchmark.py \
           --gpu "${{ github.event.inputs.gpu }}" \
           --model "${{ github.event.inputs.model }}" \
           --concurrency-levels ${{ github.event.inputs.concurrency_levels }} \
           --requests-per-level ${{ github.event.inputs.requests_per_level }} \
-          --prompt "${{ github.event.inputs.prompt }}" \
-          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }}
+          --prompt "${{ github.event.inputs.prompt }}"
+
+    - name: Teardown Instance
+      if: always()
+      env:
+        VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
+      run: |
+        python teardown.py
 
     - name: Upload results
       uses: actions/upload-artifact@v4

--- a/benchmark.py
+++ b/benchmark.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 import os
 from bench.speed_test import run_speed_test_suite
+from infra.logging_utils import log_group_start, log_group_end, log_notice, log_error, log_group_cb
 
 async def main():
     parser = argparse.ArgumentParser(description="Run LLM Benchmark Suite")
@@ -29,7 +30,7 @@ async def main():
             api_url = f.read().strip()
 
     if not api_url:
-        print("ERROR: API URL not provided and .vast_api_url not found.")
+        log_error("API URL not provided and .vast_api_url not found.")
         sys.exit(1)
 
     email_config = None
@@ -53,10 +54,11 @@ async def main():
             requests_per_level=args.requests_per_level,
             prompt=args.prompt,
             email_config=email_config,
-            api_key="vllm-benchmark-token"
+            api_key="vllm-benchmark-token",
+            log_group_cb=log_group_cb
         )
     except Exception as e:
-        print(f"ERROR: Benchmarking failed: {e}")
+        log_error(f"Benchmarking failed: {e}")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/infra/logging_utils.py
+++ b/infra/logging_utils.py
@@ -1,0 +1,29 @@
+import os
+
+def log_group_start(title):
+    if os.getenv("GITHUB_ACTIONS"):
+        print(f"::group::{title}")
+    else:
+        print(f"\n--- {title} ---")
+
+def log_group_end():
+    if os.getenv("GITHUB_ACTIONS"):
+        print("::endgroup::")
+
+def log_notice(msg):
+    if os.getenv("GITHUB_ACTIONS"):
+        print(f"::notice::{msg}")
+    else:
+        print(f"NOTICE: {msg}")
+
+def log_error(msg):
+    if os.getenv("GITHUB_ACTIONS"):
+        print(f"::error::{msg}")
+    else:
+        print(f"ERROR: {msg}")
+
+def log_group_cb(title):
+    if title:
+        log_group_start(title)
+    else:
+        log_group_end()

--- a/provision.py
+++ b/provision.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 import os
 from infra.vast_manager import VastManager
+from infra.logging_utils import log_group_start, log_group_end, log_notice, log_error
 
 async def main():
     parser = argparse.ArgumentParser(description="Provision Vast.ai Instance for LLM Benchmarking")
@@ -15,6 +16,7 @@ async def main():
     vast = VastManager()
 
     try:
+        log_group_start("Infrastructure Provisioning")
         offers = vast.find_offers(args.gpu)
         if not offers:
             raise RuntimeError(f"No offers found for {args.gpu}")
@@ -41,9 +43,11 @@ async def main():
         if not await vast.wait_for_api_ready(api_url, api_key=vllm_api_key, timeout=args.wait_timeout):
             raise RuntimeError("API failed to become ready")
 
-        print(f"Provisioning successful. API URL: {api_url}")
+        log_notice(f"Provisioning successful. API URL: {api_url}")
+        log_group_end()
     except Exception as e:
-        print(f"ERROR: Provisioning failed: {e}")
+        log_group_end()
+        log_error(f"Provisioning failed: {e}")
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/teardown.py
+++ b/teardown.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from infra.vast_manager import VastManager
+from infra.logging_utils import log_group_start, log_group_end, log_notice, log_error
 
 def main():
     parser = argparse.ArgumentParser(description="Teardown Vast.ai Instance")
@@ -15,12 +16,14 @@ def main():
             instance_id = f.read().strip()
 
     if instance_id:
-        print(f"Destroying instance {instance_id}...")
+        log_group_start("Infrastructure Teardown")
+        log_notice(f"Destroying instance {instance_id}...")
         vast.destroy_instance(instance_id)
         if os.path.exists(".vast_instance_id"):
             os.remove(".vast_instance_id")
         if os.path.exists(".vast_api_url"):
             os.remove(".vast_api_url")
+        log_group_end()
     else:
         print("No instance ID found to teardown.")
 


### PR DESCRIPTION
This change refactors the main benchmarking workflow in GitHub Actions to be more modular. Instead of a single monolithic step, it now uses three distinct steps for provisioning, benchmarking, and teardown. This improves observability and ensures that instances are destroyed even if the benchmark fails (using `if: always()`). The scripts `provision.py`, `benchmark.py`, and `teardown.py` were updated to handle these roles independently while sharing state through standard file markers. Logging has also been improved with GitHub Actions grouping and notices.

Fixes #70

---
*PR created automatically by Jules for task [10871863124386371078](https://jules.google.com/task/10871863124386371078) started by @chatelao*