### PR TITLE
Manual Verification Mode and Test Disabling

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -53,7 +53,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Provision Vast.ai Instance
+    - name: Launching the vLLM (active)
       env:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -61,9 +61,22 @@ jobs:
         python provision.py \
           --gpu "${{ github.event.inputs.gpu }}" \
           --model "${{ github.event.inputs.model }}" \
-          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }}
+          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }} \
+          --only-launch
 
-    - name: Run Benchmark
+    - name: Waiting for vLLM to be running (active)
+      env:
+        VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      run: |
+        python provision.py \
+          --gpu "${{ github.event.inputs.gpu }}" \
+          --model "${{ github.event.inputs.model }}" \
+          ${{ github.event.inputs.template_hash && format('--template-hash {0}', github.event.inputs.template_hash) || '' }} \
+          --only-wait
+
+    - name: Running the tests (inactive)
+      if: false
       run: |
         python benchmark.py \
           --gpu "${{ github.event.inputs.gpu }}" \
@@ -72,8 +85,8 @@ jobs:
           --requests-per-level ${{ github.event.inputs.requests_per_level }} \
           --prompt "${{ github.event.inputs.prompt }}"
 
-    - name: Teardown Instance
-      if: always()
+    - name: Stopping the vLLM (inactive)
+      if: false
       env:
         VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
       run: |
@@ -81,7 +94,7 @@ jobs:
 
     - name: Upload results
       uses: actions/upload-artifact@v4
-      if: always()
+      if: always() && false
       with:
         name: benchmark-results
         path: benchmark_*.json

--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -45,7 +45,6 @@ jobs:
         cat benchmark_mock-gpu_*.json | jq '.'
 
   verify-with-vllm:
-    if: false
     runs-on: ubuntu-latest
     env:
       VLLM_TARGET_DEVICE: cpu

--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   verify-with-mock:
+    if: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -45,6 +46,7 @@ jobs:
         cat benchmark_mock-gpu_*.json | jq '.'
 
   verify-with-vllm:
+    if: false
     runs-on: ubuntu-latest
     env:
       VLLM_TARGET_DEVICE: cpu

--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -45,6 +45,7 @@ jobs:
         cat benchmark_mock-gpu_*.json | jq '.'
 
   verify-with-vllm:
+    if: false
     runs-on: ubuntu-latest
     env:
       VLLM_TARGET_DEVICE: cpu

--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   verify-with-mock:
-    if: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -46,7 +45,6 @@ jobs:
         cat benchmark_mock-gpu_*.json | jq '.'
 
   verify-with-vllm:
-    if: false
     runs-on: ubuntu-latest
     env:
       VLLM_TARGET_DEVICE: cpu

--- a/provision.py
+++ b/provision.py
@@ -11,27 +11,45 @@ async def main():
     parser.add_argument("--model", type=str, required=True, help="Model name")
     parser.add_argument("--template-hash", type=str, default="38b2b68cf896e8582dff6f305a2041b1", help="Vast.ai template hash")
     parser.add_argument("--wait-timeout", type=int, default=1200, help="Wait timeout in seconds")
+    parser.add_argument("--only-launch", action="store_true", help="Only launch the instance and exit")
+    parser.add_argument("--only-wait", action="store_true", help="Wait for an existing instance to be ready")
 
     args = parser.parse_args()
     vast = VastManager()
+    vllm_api_key = "vllm-benchmark-token"
 
     try:
-        log_group_start("Infrastructure Provisioning")
-        offers = vast.find_offers(args.gpu)
-        if not offers:
-            raise RuntimeError(f"No offers found for {args.gpu}")
+        instance_id = None
+        if args.only_wait:
+            if not os.path.exists(".vast_instance_id"):
+                raise RuntimeError(".vast_instance_id file not found, cannot wait for instance")
+            with open(".vast_instance_id", "r") as f:
+                instance_id = int(f.read().strip())
+            log_group_start(f"Waiting for Existing Instance {instance_id}")
+        else:
+            log_group_start("Infrastructure Provisioning")
+            offers = vast.find_offers(args.gpu)
+            if not offers:
+                raise RuntimeError(f"No offers found for {args.gpu}")
 
-        offer_id = offers[0]['id']
-        vllm_api_key = "vllm-benchmark-token"
-        env_vars = vast.get_vllm_env_vars(args.model, api_key=vllm_api_key)
+            offer_id = offers[0]['id']
+            env_vars = vast.get_vllm_env_vars(args.model, api_key=vllm_api_key)
 
-        instance_id = vast.rent_instance(offer_id, template_hash=args.template_hash, env=env_vars)
-        if not instance_id:
-            raise RuntimeError("Failed to rent instance")
+            instance_id = vast.rent_instance(offer_id, template_hash=args.template_hash, env=env_vars)
+            if not instance_id:
+                raise RuntimeError("Failed to rent instance")
 
-        with open(".vast_instance_id", "w") as f:
-            f.write(str(instance_id))
+            with open(".vast_instance_id", "w") as f:
+                f.write(str(instance_id))
 
+            log_notice(f"Instance {instance_id} launched.")
+
+        if args.only_launch:
+            log_notice(f"Only-launch requested. Instance {instance_id} is being provisioned.")
+            log_group_end()
+            return
+
+        # Wait phase
         if not vast.wait_for_ssh(instance_id, timeout=args.wait_timeout):
             raise RuntimeError(f"Instance {instance_id} failed to initialize")
 
@@ -43,11 +61,14 @@ async def main():
         if not await vast.wait_for_api_ready(api_url, api_key=vllm_api_key, timeout=args.wait_timeout):
             raise RuntimeError("API failed to become ready")
 
-        log_notice(f"Provisioning successful. API URL: {api_url}")
+        log_notice(f"Provisioning successful.")
+        log_notice(f"API URL: {api_url}")
+        log_notice(f"Bearer Token: {vllm_api_key}")
+        log_notice(f"Verify manually with: curl -H 'Authorization: Bearer {vllm_api_key}' {api_url}/v1/models")
         log_group_end()
     except Exception as e:
         log_group_end()
-        log_error(f"Provisioning failed: {e}")
+        log_error(f"Operation failed: {e}")
         sys.exit(1)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change transitions the CI/CD pipeline into a manual verification mode. It decouples the instance provisioning process into two active steps: launching the vLLM and waiting for it to be ready. Automated benchmarking and instance teardown are disabled, allowing the LLM to persist for manual inspection. The `provision.py` script now explicitly logs the resolved API URL and Bearer Token, providing a ready-to-use curl command for verification. Additionally, all auxiliary CI tests have been disabled.

Fixes #72

---
*PR created automatically by Jules for task [8873874698379348359](https://jules.google.com/task/8873874698379348359) started by @chatelao*