### PR TITLE
Add activation bars to architecture.puml

### DIFF
--- a/architecture.puml
+++ b/architecture.puml
@@ -6,38 +6,39 @@ participant LoadTester as "Load Test Engine\n(bench/speed_test.py)"
 participant VastAPI as "Vast.ai API"
 participant GPUInstance as "GPU Instance\n(vLLM / Model)"
 
-User -> Orchestrator: Run benchmark suite
-Orchestrator -> VastManager: find_offers(gpu_name)
-VastManager -> VastAPI: GET /offers
-VastAPI --> VastManager: List of offers
-VastManager --> Orchestrator: Offers
+User -> Orchestrator ++ : Run benchmark suite
+Orchestrator -> VastManager ++ : find_offers(gpu_name)
+VastManager -> VastAPI ++ : GET /offers
+VastAPI --> VastManager -- : List of offers
+VastManager --> Orchestrator -- : Offers
 
-Orchestrator -> VastManager: rent_instance(offer_id, template, env)
-VastManager -> VastAPI: POST /instances
-VastAPI --> VastManager: Instance ID
-VastManager --> Orchestrator: Instance ID
+Orchestrator -> VastManager ++ : rent_instance(offer_id, template, env)
+VastManager -> VastAPI ++ : POST /instances
+VastAPI --> VastManager -- : Instance ID
+VastManager --> Orchestrator -- : Instance ID
 
-Orchestrator -> VastManager: wait_for_ssh(instance_id)
-VastManager -> VastAPI: GET /instances
-VastAPI --> VastManager: Instance details (IP/Port)
-VastManager --> Orchestrator: Connection details
+Orchestrator -> VastManager ++ : wait_for_ssh(instance_id)
+VastManager -> VastAPI ++ : GET /instances
+VastAPI --> VastManager -- : Instance details (IP/Port)
+VastManager --> Orchestrator -- : Connection details
 
-Orchestrator -> VastManager: wait_for_api_ready(api_url)
-VastManager -> GPUInstance: GET /v1/models
-GPUInstance --> VastManager: 200 OK
-VastManager --> Orchestrator: API Ready
+Orchestrator -> VastManager ++ : wait_for_api_ready(api_url)
+VastManager -> GPUInstance ++ : GET /v1/models
+GPUInstance --> VastManager -- : 200 OK
+VastManager --> Orchestrator -- : API Ready
 
-Orchestrator -> LoadTester: run_benchmark_suite(api_url, model)
+Orchestrator -> LoadTester ++ : run_benchmark_suite(api_url, model)
 loop for each concurrency level
-    LoadTester -> GPUInstance: POST /v1/chat/completions (stream=True)
-    GPUInstance --> LoadTester: Token stream
+    LoadTester -> GPUInstance ++ : POST /v1/chat/completions (stream=True)
+    GPUInstance --> LoadTester -- : Token stream
 end
-LoadTester --> Orchestrator: Performance metrics (TTFT, ITL, TPS)
+LoadTester --> Orchestrator -- : Performance metrics (TTFT, ITL, TPS)
 
-Orchestrator -> User: Display results & Save report
+Orchestrator -> User : Display results & Save report
 
-Orchestrator -> VastManager: teardown_instance()
-VastManager -> VastAPI: DELETE /instances/{id}
-VastAPI --> VastManager: Success
-VastManager --> Orchestrator: Done
+Orchestrator -> VastManager ++ : teardown_instance()
+VastManager -> VastAPI ++ : DELETE /instances/{id}
+VastAPI --> VastManager -- : Success
+VastManager --> Orchestrator -- : Done
+return
 @enduml


### PR DESCRIPTION
This PR adds activation bars to the architecture sequence diagram in `architecture.puml`. The changes improve the visual clarity of the component interactions by showing when each participant is actively processing a request. 

Summary of changes:
- Orchestrator is activated when the User runs the benchmark suite and deactivated after the teardown.
- VastManager, VastAPI, LoadTester, and GPUInstance are activated on calls and deactivated when they return.
- The `++`/`--` and `return` shorthand for activations in PlantUML was used.

Fixes #81

---
*PR created automatically by Jules for task [9394701228337750950](https://jules.google.com/task/9394701228337750950) started by @chatelao*