### PR TITLE
Fix NameError in mock server

### DIFF
--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -87,7 +87,6 @@ app = web.Application()
 # vLLM Endpoints
 app.router.add_post('/v1/chat/completions', chat_completions)
 app.router.add_get('/v1/models', get_models)
-app.router.add_get('/v1/models', models_handler)
 
 app.router.add_post('/api/v0/bundles/', search_offers)
 app.router.add_put('/api/v0/asks/{id}/', create_instance)


### PR DESCRIPTION
Fixed a `NameError` in `tests/mock_server.py` that prevented the mock server from starting. The traceback indicated that `models_handler` was not defined. I removed the redundant line `app.router.add_get('/v1/models', models_handler)` as the preceding line already correctly registers the `/v1/models` endpoint using the `get_models` function. Verified the fix by running the full end-to-end integration test suite against the mock server.

Fixes #98

---
*PR created automatically by Jules for task [17847256912546770859](https://jules.google.com/task/17847256912546770859) started by @chatelao*