### PR TITLE
Fix AI benchmark results uploading and improve script error handling

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -16,7 +16,7 @@ on:
       model:
         description: 'LLM model name'
         required: true
-        default: 'facebook/opt-125m'
+        default: 'google/gemma-2-9b-it'
         type: choice
         options:
         - 'facebook/opt-125m'
@@ -92,4 +92,7 @@ jobs:
       if: always()
       with:
         name: benchmark-results
-        path: results.json
+        path: |
+          results.json
+          benchmark_*.json
+        if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv/
 ENV/
 *.log
 benchmark_*.json
+results.json

--- a/benchmark.py
+++ b/benchmark.py
@@ -39,6 +39,8 @@ class LoadTester:
         try:
             async with session.post(url, json=payload, headers=headers) as response:
                 if response.status != 200:
+                    text = await response.text()
+                    log(f"::error::Request failed with status {response.status}: {text[:200]}")
                     return None
 
                 async for line in response.content:
@@ -52,7 +54,8 @@ class LoadTester:
 
             duration = time.perf_counter() - start_time
             return {"ttft": ttft, "tokens": tokens, "duration": duration}
-        except Exception:
+        except Exception as e:
+            log(f"::error::Exception during request: {type(e).__name__}: {e}")
             return None
 
     async def run(self, concurrency, num_requests, prompt):
@@ -118,6 +121,9 @@ async def main():
         with open("results.json", "w") as f:
             json.dump(all_results, f, indent=2)
         log(f"Results written to results.json")
+    else:
+        log("::error::No results collected. Exiting with failure.")
+        sys.exit(1)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
This PR improves the reliability and visibility of the AI benchmark process. Key changes include:
- **Enhanced Debugging:** `benchmark.py` now logs HTTP status codes and the first 200 characters of error responses, as well as detailed exception information.
- **Fail-Fast CI:** The benchmark script now explicitly exits with a non-zero status code if no data is collected, and the GitHub Action workflow is configured to fail if result artifacts are missing.
- **Artifact Management:** The workflow now uploads both the main `results.json` and timestamped individual run files.
- **Project Alignment:** The default model is updated to `google/gemma-2-9b-it`, and `results.json` is added to `.gitignore` to prevent accidental commits of benchmark data.

Fixes #100

---
*PR created automatically by Jules for task [10732186439624159946](https://jules.google.com/task/10732186439624159946) started by @chatelao*