### PR TITLE
Fix benchmark failure with Transformers v4.44 chat template requirement

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -40,6 +40,13 @@ def main():
     hf_token = os.getenv("HF_TOKEN", "")
     vllm_api_key = "vllm-benchmark-token"
     vllm_args = "--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000"
+
+    # As of transformers v4.44, certain models (like OPT) require a chat template to be explicitly provided.
+    # We provide a basic template if the model is from a family known to lack one.
+    models_needing_template = ["facebook/opt-125m"]
+    if any(m in args.model for m in models_needing_template):
+        vllm_args += " --chat-template \"{% for message in messages %}{{ message['content'] }}{% endfor %}\""
+
     env_str = f"-e VLLM_MODEL={args.model} -e VLLM_ARGS='{vllm_args}' -e HF_TOKEN={hf_token} -e OPEN_BUTTON_TOKEN={vllm_api_key} -p 1111:1111 -p 7860:7860 -p 8000:8000 -p 8265:8265 -p 8080:8080"
     env_dict = parse_env(env_str)
 

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -11,6 +11,24 @@ async def chat_completions(request):
     except Exception:
         data = {}
 
+    # Check for chat template requirement simulation
+    if instances:
+        # Just pick the first instance for simplicity in mock
+        inst = list(instances.values())[0]
+        env = inst.get("env", {})
+        model = env.get("VLLM_MODEL", "")
+        args = env.get("VLLM_ARGS", "")
+
+        # Simulate transformers v4.44 requirement for certain models
+        if "facebook/opt" in model and "--chat-template" not in args:
+            return web.json_response({
+                "error": {
+                    "message": "As of transformers v4.44, default chat template is no longer allowed, so you must provide a chat template if the tokenizer does not define one.",
+                    "type": "BadRequestError",
+                    "param": None
+                }
+            }, status=400)
+
     stream = data.get("stream", False)
 
     if not stream:
@@ -52,6 +70,11 @@ async def search_offers(request):
     })
 
 async def create_instance(request):
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+
     offer_id = request.match_info['id']
     instance_id = 2001
     instances[str(instance_id)] = {
@@ -59,7 +82,8 @@ async def create_instance(request):
         "actual_status": "loading",
         "public_ipaddr": "127.0.0.1",
         "ports": {"8000/tcp": [{"HostIp": "0.0.0.0", "HostPort": "8000"}]},
-        "status_msg": "Loading..."
+        "status_msg": "Loading...",
+        "env": data.get("env", {})
     }
     # Simulate transitioning to running after a short delay
     asyncio.create_task(make_instance_running(str(instance_id)))


### PR DESCRIPTION
Fixed the benchmark failure where models without a predefined chat template (e.g., `facebook/opt-125m`) would fail with an HTTP 400 error when using the Chat Completions API with `transformers >= v4.44`. 

Changes:
- Modified `launch.py` to conditionally append `--chat-template` to `VLLM_ARGS` for known problematic model families.
- Updated `tests/mock_server.py` to simulate this behavior by checking the instance's environment during chat completion requests.
- Ensured `poll.py` remains unchanged (reverted accidental polling frequency changes).

Fixes #102

---
*PR created automatically by Jules for task [12344994749763976587](https://jules.google.com/task/12344994749763976587) started by @chatelao*