### PR TITLE
Add bigger Gemma 4 models to benchmark workflow

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -22,6 +22,8 @@ on:
         - 'facebook/opt-125m'
         - 'google/gemma-4-E2B-it'
         - 'google/gemma-4-E4B-it'
+        - 'google/gemma-4-26B-A4B-it'
+        - 'google/gemma-4-31B-it'
         - 'google/gemma-2-9b-it'
         - 'mistralai/Mistral-Small-Instruct-2409'
         - 'mistralai/Mistral-Large-Instruct-2411'


### PR DESCRIPTION
Added `google/gemma-4-26B-A4B-it` and `google/gemma-4-31B-it` to the `workflow_dispatch` model selection in `.github/workflows/vast_ai_benchmark.yml`. Verified model existence on Hugging Face and confirmed script compatibility via end-to-end integration tests using the mock server.

Fixes #106

---
*PR created automatically by Jules for task [10157187357576180011](https://jules.google.com/task/10157187357576180011) started by @chatelao*