### PR TITLE
Fix Gemma 4 model loading error in vLLM template

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -47,6 +47,10 @@ def main():
     if any(m in args.model for m in models_needing_template):
         vllm_args += " --chat-template \"{% for message in messages %}{{ message.content }}{% endfor %}\""
 
+    # Gemma 4 models require --trust-remote-code because the architecture is often newer than the transformers version in the template.
+    if "gemma-4" in args.model:
+        vllm_args += " --trust-remote-code"
+
     env_dict = {
         "VLLM_MODEL": args.model,
         "VLLM_ARGS": vllm_args,

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -80,6 +80,18 @@ async def chat_completions(request):
 async def get_models(request):
     if not is_authorized(request):
         return web.json_response({"error": "Unauthorized"}, status=401)
+
+    # Simulate gemma4 architecture failure if --trust-remote-code is missing
+    if instances:
+        for inst in instances.values():
+            env = inst.get("env", {})
+            model = env.get("VLLM_MODEL", "")
+            args = env.get("VLLM_ARGS", "")
+            if "gemma-4" in model and "--trust-remote-code" not in args:
+                return web.json_response({
+                    "error": "The checkpoint you are trying to load has model type gemma4 but Transformers does not recognize this architecture."
+                }, status=500)
+
     return web.json_response({"data": [{"id": "tiny-model"}]})
 
 async def search_offers(request):


### PR DESCRIPTION
This PR fixes an issue where Gemma 4 models failed to load in the Vast.ai vLLM template due to an unrecognized architecture. By automatically enabling `--trust-remote-code` for these models, vLLM can load the necessary architecture definition from Hugging Face. The change includes:
- Conditional logic in `launch.py` to add the flag.
- Updated `tests/mock_server.py` to simulate the error and the fix.
- Verification using the project's mock-based integration test suite.

Fixes #111

---
*PR created automatically by Jules for task [7045170741160205114](https://jules.google.com/task/7045170741160205114) started by @chatelao*