### PR TITLE
Add vllm/vllm-openai:latest image option and template dropdown

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -35,10 +35,18 @@ on:
         description: 'Number of requests per concurrency level'
         required: true
         default: '10'
-      template_hash:
-        description: 'Vast.ai template hash'
-        required: false
+      template:
+        description: 'Vast.ai template hash or Docker image'
+        required: true
         default: '38b2b68cf896e8582dff6f305a2041b1'
+        type: choice
+        options:
+        - '38b2b68cf896e8582dff6f305a2041b1'
+        - 'vllm/vllm-openai:latest'
+      disk:
+        description: 'Disk size in GB'
+        required: true
+        default: '10'
 
 jobs:
   benchmark:
@@ -66,7 +74,8 @@ jobs:
         python launch.py \
           --gpu "${{ github.event.inputs.gpu }}" \
           --model "${{ github.event.inputs.model }}" \
-          --template-hash "${{ github.event.inputs.template_hash }}"
+          --template "${{ github.event.inputs.template }}" \
+          --disk "${{ github.event.inputs.disk }}"
 
     - name: Poll
       env:

--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -16,12 +16,13 @@ The system is composed of four standalone Python scripts orchestrated by GitHub 
 
 ### 1. Provisioning (`launch.py`)
 - **Responsibility:** Automated marketplace search and instance rental.
-- **Inputs:** GPU name, Model name, Template Hash.
+- **Inputs:** GPU name, Model name, Template (Hash or Docker Image), Disk size.
 - **Outputs:** Persists the Instance ID to `.vast_instance_id`.
 - **Features:**
     - Queries Vast.ai for specific GPU models (e.g., RTX 4090).
     - Configures vLLM environment variables and port mappings (8000 for API).
-    - Uses predefined template hashes for consistent deployments.
+    - Supports both predefined template hashes and direct Docker images (e.g., `vllm/vllm-openai:latest`).
+    - Configurable disk size for large models.
 
 ### 2. Readiness Check (`poll.py`)
 - **Responsibility:** Verifies the instance is running and the vLLM API is healthy.

--- a/GEMMA.md
+++ b/GEMMA.md
@@ -17,7 +17,7 @@ Compare LLM model performances using vast.ai as remote GPU / vLLM provider:
 - H100
 
 # HOWTO
-- Use the vast.ai template "38b2b68cf896e8582dff6f305a2041b1" to setup a vLLM instance.
+- Use the vast.ai template "38b2b68cf896e8582dff6f305a2041b1" or a Docker image like "vllm/vllm-openai:latest" to setup a vLLM instance.
 - General rule: Add a date/timestamp to every line logged.
 
 # Secrets 

--- a/launch.py
+++ b/launch.py
@@ -13,7 +13,8 @@ def main():
     parser = argparse.ArgumentParser(description="Launch Vast.ai vLLM instance")
     parser.add_argument("--gpu", type=str, default="RTX_4090")
     parser.add_argument("--model", type=str, required=True)
-    parser.add_argument("--template-hash", type=str, default="38b2b68cf896e8582dff6f305a2041b1")
+    parser.add_argument("--template", "--template-hash", dest="template", type=str, default="38b2b68cf896e8582dff6f305a2041b1")
+    parser.add_argument("--disk", type=float, default=10)
     args = parser.parse_args()
 
     api_key = os.getenv("VAST_AI_API_KEY")
@@ -60,8 +61,16 @@ def main():
         "-p 8080:8080": "1"
     }
 
-    log(f"Renting instance with template {args.template_hash}...")
-    result = sdk.create_instance(id=offer_id, template_hash=args.template_hash, env=env_dict)
+    # Determine if it's a template hash or a docker image
+    # Template hashes are usually hex strings, while images contain '/' or ':'
+    is_image = "/" in args.template or ":" in args.template
+
+    if is_image:
+        log(f"Renting instance with image {args.template} and {args.disk}GB disk...")
+        result = sdk.create_instance(id=offer_id, image=args.template, disk=args.disk, env=env_dict)
+    else:
+        log(f"Renting instance with template {args.template} and {args.disk}GB disk...")
+        result = sdk.create_instance(id=offer_id, template_hash=args.template, disk=args.disk, env=env_dict)
     if result.get("success"):
         instance_id = result.get("new_contract")
         log(f"Successfully created instance {instance_id}")


### PR DESCRIPTION
This PR adds support for using the `vllm/vllm-openai:latest` Docker image as an alternative to the default Vast.ai template hash in the benchmarking workflow.

Key changes:
- `launch.py`: Now accepts a `--template` argument (aliased as `--template-hash`) and automatically detects if it's a Docker image (contains `/` or `:`) or a template hash. Added a `--disk` argument to allow users to specify the required disk space, which is especially important when using raw Docker images for large models.
- `.github/workflows/vast_ai_benchmark.yml`: Replaced the `template_hash` text input with a `template` dropdown (choice) menu featuring the default template hash and the new `vllm/vllm-openai:latest` image. Added a `disk` input for easier configuration of instance storage.
- Documentation: Updated `CONCEPT.md` and `GEMMA.md` to reflect these new capabilities.

The changes were verified using the local mock server, ensuring that both template hashes and Docker images are correctly handled during the instance creation process and that the full benchmarking lifecycle remains functional.

Fixes #112

---
*PR created automatically by Jules for task [2313926473948945754](https://jules.google.com/task/2313926473948945754) started by @chatelao*