### PR TITLE
Fix inconsistent vLLM authentication and enhance diagnostic logging

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -93,7 +93,8 @@ async def main():
         with open(".vast_api_url", "r") as f:
             api_url = f.read().strip()
 
-    tester = LoadTester(api_url, args.model, "vllm-benchmark-token")
+    vllm_api_key = os.getenv("VLLM_API_KEY_OVERRIDE", "vllm-benchmark-token")
+    tester = LoadTester(api_url, args.model, vllm_api_key)
     all_results = []
 
     log(f"Starting benchmark for {args.model}...")

--- a/launch.py
+++ b/launch.py
@@ -39,8 +39,8 @@ def main():
     log(f"Found offer {offer_id} at ${offers[0].get('dph_total'):.3f}/hr")
 
     hf_token = os.getenv("HF_TOKEN", "")
-    vllm_api_key = "vllm-benchmark-token"
-    vllm_args = "--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000"
+    vllm_api_key = os.getenv("VLLM_API_KEY_OVERRIDE", "vllm-benchmark-token")
+    vllm_args = f"--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000 --api-key {vllm_api_key}"
 
     # As of transformers v4.44, certain models (like OPT) require a chat template to be explicitly provided.
     # We provide a basic template if the model is from a family known to lack one.

--- a/poll.py
+++ b/poll.py
@@ -62,7 +62,8 @@ async def wait_for_api(url, api_key, timeout=1200):
                         log(f"Response: {content[:200]}...")
                         return True
                     elif resp.status == 401:
-                        log("Error: 401 Unauthorized. Check Bearer Token.")
+                        text = await resp.text()
+                        log(f"Error: 401 Unauthorized. Check Bearer Token. Detail: {text[:200]}")
                     else:
                         text = await resp.text()
                         log(f"Detail: {text[:100]}")
@@ -131,7 +132,8 @@ async def main():
     with open(".vast_api_url", "w") as f:
         f.write(api_url)
 
-    if await wait_for_api(api_url, "vllm-benchmark-token"):
+    vllm_api_key = os.getenv("VLLM_API_KEY_OVERRIDE", "vllm-benchmark-token")
+    if await wait_for_api(api_url, vllm_api_key):
         log("\n--- Polling SUCCESS ---")
     else:
         log("::error::API failed to respond 200 OK within 20 minutes")


### PR DESCRIPTION
I have fixed the intermittent 401 Unauthorized errors by ensuring the vLLM server is explicitly configured with the same API key used by the polling and benchmarking scripts. I also introduced a `VLLM_API_KEY_OVERRIDE` environment variable for easier configuration and enhanced the polling script's diagnostic logging for 401 errors. These changes have been verified with integration tests.

Fixes #107

---
*PR created automatically by Jules for task [9987229656443952656](https://jules.google.com/task/9987229656443952656) started by @chatelao*