### PR TITLE
Support multi-GPU LLM benchmarking

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -19,6 +19,15 @@ on:
         - 'H200'
         - 'H200_NVL'
         - 'B200'
+      num_gpus:
+        description: 'Number of GPUs'
+        required: true
+        default: '1'
+        type: choice
+        options:
+        - '1'
+        - '2'
+        - '4'
       model:
         description: 'LLM model name'
         required: true
@@ -82,6 +91,7 @@ jobs:
       run: |
         python launch.py \
           --gpu "${{ github.event.inputs.gpu }}" \
+          --num-gpus "${{ github.event.inputs.num_gpus }}" \
           --model "${{ github.event.inputs.model }}" \
           --template "${{ github.event.inputs.template }}" \
           --disk "${{ github.event.inputs.disk }}"
@@ -96,6 +106,7 @@ jobs:
       run: |
         python benchmark.py \
           --gpu "${{ github.event.inputs.gpu }}" \
+          --num-gpus "${{ github.event.inputs.num_gpus }}" \
           --model "${{ github.event.inputs.model }}" \
           --concurrency-levels ${{ github.event.inputs.concurrency_levels }} \
           --requests-per-level ${{ github.event.inputs.requests_per_level }}

--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -56,5 +56,5 @@ jobs:
 
     - name: Check benchmark results
       run: |
-        ls benchmark_mock-gpu_*.json
-        cat benchmark_mock-gpu_*.json | jq '.'
+        ls benchmark_*_mock-gpu_*.json
+        cat benchmark_*_mock-gpu_*.json | jq '.'

--- a/benchmark.py
+++ b/benchmark.py
@@ -80,6 +80,7 @@ async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True)
     parser.add_argument("--gpu", default="RTX_4090")
+    parser.add_argument("--num-gpus", type=int, default=1)
     parser.add_argument("--url", help="Override API URL")
     parser.add_argument("--concurrency-levels", type=int, nargs="+", default=[1, 4, 16])
     parser.add_argument("--requests-per-level", type=int, default=10)
@@ -109,13 +110,14 @@ async def main():
         summary_file = os.getenv("GITHUB_STEP_SUMMARY")
         if summary_file:
             with open(summary_file, "a") as f:
-                f.write(f"## Results: {args.model} on {args.gpu}\n")
+                f.write(f"## Results: {args.model} on {args.num_gpus}x {args.gpu}\n")
                 f.write("| C | Avg TTFT | Avg TPS | Total TPS |\n|---|---|---|---|\n")
                 for r in all_results:
                     f.write(f"| {r['concurrency']} | {r['avg_ttft']:.3f} | {r['avg_tps']:.2f} | {r['total_tps']:.2f} |\n")
             log(f"Summary written to {summary_file}")
 
-        output_file = f"benchmark_{args.gpu.replace(' ', '_')}_{int(time.time())}.json"
+        gpu_str = f"{args.num_gpus}x_{args.gpu.replace(' ', '_')}"
+        output_file = f"benchmark_{gpu_str}_{int(time.time())}.json"
         with open(output_file, "w") as f:
             json.dump(all_results, f, indent=2)
         log(f"Results written to {output_file}")

--- a/launch.py
+++ b/launch.py
@@ -38,6 +38,7 @@ def estimate_model_params(model_name):
 def main():
     parser = argparse.ArgumentParser(description="Launch Vast.ai vLLM instance")
     parser.add_argument("--gpu", type=str, default="RTX_4090")
+    parser.add_argument("--num-gpus", type=int, default=1)
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--template", "--template-hash", dest="template", type=str, default="38b2b68cf896e8582dff6f305a2041b1")
     parser.add_argument("--disk", type=float, default=10)
@@ -56,18 +57,19 @@ def main():
 
     params_billions = estimate_model_params(args.model)
     model_size_gb = params_billions * 2
-    required_vram = model_size_gb + 12
+    required_vram_per_gpu = (model_size_gb / args.num_gpus) + 12
     required_disk = model_size_gb + 12
     effective_disk = max(args.disk, required_disk)
 
     log(f"Estimated parameters: {params_billions:.2f}B")
-    log(f"Required VRAM: {required_vram:.2f}GB")
+    log(f"Total model size: {model_size_gb:.2f}GB")
+    log(f"Required VRAM per GPU ({args.num_gpus} GPUs): {required_vram_per_gpu:.2f}GB")
     log(f"Required Disk: {effective_disk:.2f}GB (model requires {required_disk:.2f}GB, user requested {args.disk}GB)")
 
     gpu_name = args.gpu.replace("_", " ")
-    log(f"Searching for {gpu_name}...")
+    log(f"Searching for {args.num_gpus}x {gpu_name}...")
     # Quoting the GPU name because it contains spaces
-    query = f"gpu_name=\"{gpu_name}\" num_gpus=1 rentable=True verified=True cuda_max_good>=12.4 inet_down>200 gpu_ram>={required_vram} disk_space>={effective_disk}"
+    query = f"gpu_name=\"{gpu_name}\" num_gpus={args.num_gpus} rentable=True verified=True cuda_max_good>=12.4 inet_down>200 gpu_ram>={required_vram_per_gpu} disk_space>={effective_disk}"
     offers = sdk.search_offers(query=query, order="dph_total")
     if not offers:
         log(f"::error::No offers found for {args.gpu}")
@@ -79,6 +81,9 @@ def main():
     hf_token = os.getenv("HF_TOKEN", "")
     vllm_api_key = os.getenv("VLLM_API_KEY_OVERRIDE", "vllm-benchmark-token")
     vllm_args = f"--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000 --api-key {vllm_api_key}"
+
+    if args.num_gpus > 1:
+        vllm_args += f" --tensor-parallel-size {args.num_gpus}"
 
     # As of transformers v4.44, certain models (like OPT) require a chat template to be explicitly provided.
     # We provide a basic template if the model is from a family known to lack one.


### PR DESCRIPTION
This change adds the ability to run LLM benchmarks on 1, 2, or 4 GPUs. It updates the provisioning logic to request multiple GPUs from Vast.ai, configures vLLM's tensor parallelism accordingly, and improves the benchmarking report to clearly indicate the GPU count.

Fixes #120

---
*PR created automatically by Jules for task [3668747347786892299](https://jules.google.com/task/3668747347786892299) started by @chatelao*