### PR TITLE
Add top 3 coding models to benchmark list

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -42,6 +42,9 @@ on:
         - 'google/gemma-2-9b-it'
         - 'mistralai/Mistral-Small-Instruct-2409'
         - 'mistralai/Mistral-Large-Instruct-2411'
+        - 'Qwen/Qwen2.5-Coder-32B-Instruct'
+        - 'deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct'
+        - 'mistralai/Codestral-22B-v0.1'
       concurrency_levels:
         description: 'Space-separated concurrency levels'
         required: true

--- a/launch.py
+++ b/launch.py
@@ -21,6 +21,8 @@ def estimate_model_params(model_name):
         return 22.0
     if "mistral-large" in model_name_lower:
         return 123.0
+    if "deepseek-coder-v2-lite" in model_name_lower:
+        return 16.0
 
     # Regex to find patterns like 7b, 125m, 0.5b
     match = re.search(r"(\d+(?:\.\d+)?)\s*([mb])", model_name_lower)


### PR DESCRIPTION
This PR adds three top-performing open-weights coding models to the Vast.ai benchmark suite:
1. Qwen/Qwen2.5-Coder-32B-Instruct
2. deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
3. mistralai/Codestral-22B-v0.1

The `launch.py` script was updated to handle the parameter estimation for `DeepSeek-Coder-V2-Lite` (16B), while the others are handled by existing regex or explicit mappings. The models are now available for selection in the `workflow_dispatch` menu of the `Vast.ai LLM Benchmark` action.

Fixes #122

---
*PR created automatically by Jules for task [16726242173168491520](https://jules.google.com/task/16726242173168491520) started by @chatelao*