### PR TITLE
Add support for new LLM models to benchmark suite

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -45,6 +45,13 @@ on:
         - 'Qwen/Qwen2.5-Coder-32B-Instruct'
         - 'deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct'
         - 'mistralai/Codestral-22B-v0.1'
+        - 'moonshotai/Kimi-K2.5'
+        - 'tiiuae/Falcon3-10B-Instruct'
+        - 'meta-llama/Llama-4-Maverick-17B-128E-Instruct'
+        - 'Qwen/Qwen3-235B-A22B'
+        - 'zai-org/GLM-4.6'
+        - 'openai/gpt-oss-120b'
+        - 'Qwen/Qwen3-235B-A22B-Instruct-2507'
       concurrency_levels:
         description: 'Space-separated concurrency levels'
         required: true

--- a/GEMMA.md
+++ b/GEMMA.md
@@ -8,7 +8,13 @@ Compare LLM model performances using vast.ai as remote GPU / vLLM provider:
 - TPS/$: Cost efficiency of the hardware.
 
 ## Models to be tested
-- <tbd>
+- moonshotai/Kimi-K2.5
+- tiiuae/Falcon3-10B-Instruct
+- meta-llama/Llama-4-Maverick-17B-128E-Instruct
+- Qwen/Qwen3-235B-A22B
+- zai-org/GLM-4.6
+- openai/gpt-oss-120b
+- Qwen/Qwen3-235B-A22B-Instruct-2507
 
 ## GPUs to be tested
 - RTX_3090

--- a/launch.py
+++ b/launch.py
@@ -23,6 +23,18 @@ def estimate_model_params(model_name):
         return 123.0
     if "deepseek-coder-v2-lite" in model_name_lower:
         return 16.0
+    if "kimi-k2.5" in model_name_lower:
+        return 1100.0
+    if "falcon3-10b" in model_name_lower:
+        return 10.0
+    if "llama-4-maverick" in model_name_lower:
+        return 400.0
+    if "qwen3-235b" in model_name_lower:
+        return 235.0
+    if "glm-4.6" in model_name_lower:
+        return 357.0
+    if "gpt-oss-120b" in model_name_lower:
+        return 117.0
 
     # Regex to find patterns like 7b, 125m, 0.5b
     match = re.search(r"(\d+(?:\.\d+)?)\s*([mb])", model_name_lower)
@@ -36,6 +48,26 @@ def estimate_model_params(model_name):
 
     # Default fallback
     return 7.0 # Default to 7B if unknown
+
+def get_vllm_args(model, num_gpus, vllm_api_key):
+    vllm_args = f"--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000 --api-key {vllm_api_key}"
+
+    if num_gpus > 1:
+        vllm_args += f" --tensor-parallel-size {num_gpus}"
+
+    # As of transformers v4.44, certain models (like OPT) require a chat template to be explicitly provided.
+    # We provide a basic template if the model is from a family known to lack one.
+    models_needing_template = ["facebook/opt-125m"]
+    if any(m in model for m in models_needing_template):
+        vllm_args += " --chat-template \"{% for message in messages %}{{ message.content }}{% endfor %}\""
+
+    # Gemma 4 models require --trust-remote-code because the architecture is often newer than the transformers version in the template.
+    # New model families also often use custom architectures or are newer than the transformers version in default templates.
+    models_trust_remote_code = ["gemma-4", "kimi", "qwen3", "glm-4", "gpt-oss"]
+    if any(m in model.lower() for m in models_trust_remote_code):
+        vllm_args += " --trust-remote-code"
+
+    return vllm_args
 
 def main():
     parser = argparse.ArgumentParser(description="Launch Vast.ai vLLM instance")
@@ -82,20 +114,7 @@ def main():
 
     hf_token = os.getenv("HF_TOKEN", "")
     vllm_api_key = os.getenv("VLLM_API_KEY_OVERRIDE", "vllm-benchmark-token")
-    vllm_args = f"--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000 --api-key {vllm_api_key}"
-
-    if args.num_gpus > 1:
-        vllm_args += f" --tensor-parallel-size {args.num_gpus}"
-
-    # As of transformers v4.44, certain models (like OPT) require a chat template to be explicitly provided.
-    # We provide a basic template if the model is from a family known to lack one.
-    models_needing_template = ["facebook/opt-125m"]
-    if any(m in args.model for m in models_needing_template):
-        vllm_args += " --chat-template \"{% for message in messages %}{{ message.content }}{% endfor %}\""
-
-    # Gemma 4 models require --trust-remote-code because the architecture is often newer than the transformers version in the template.
-    if "gemma-4" in args.model:
-        vllm_args += " --trust-remote-code"
+    vllm_args = get_vllm_args(args.model, args.num_gpus, vllm_api_key)
 
     env_dict = {
         "VLLM_MODEL": args.model,

--- a/tests/test_launch_logic.py
+++ b/tests/test_launch_logic.py
@@ -1,0 +1,32 @@
+import pytest
+from launch import estimate_model_params
+
+def test_estimate_model_params_new_models():
+    assert estimate_model_params("moonshotai/Kimi-K2.5") == 1100.0
+    assert estimate_model_params("tiiuae/Falcon3-10B-Instruct") == 10.0
+    assert estimate_model_params("meta-llama/Llama-4-Maverick-17B-128E-Instruct") == 400.0
+    assert estimate_model_params("Qwen/Qwen3-235B-A22B") == 235.0
+    assert estimate_model_params("zai-org/GLM-4.6") == 357.0
+    assert estimate_model_params("openai/gpt-oss-120b") == 117.0
+    assert estimate_model_params("Qwen/Qwen3-235B-A22B-Instruct-2507") == 235.0
+
+def test_estimate_model_params_existing_models():
+    assert estimate_model_params("facebook/opt-125m") == 0.125
+    assert estimate_model_params("google/gemma-2-9b-it") == 9.0
+    assert estimate_model_params("mistralai/Mistral-Small-Instruct-2409") == 22.0
+
+from launch import get_vllm_args
+
+def test_get_vllm_args_trust_remote_code():
+    token = "test-token"
+    # Models that SHOULD have the flag
+    assert "--trust-remote-code" in get_vllm_args("moonshotai/Kimi-K2.5", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("Qwen/Qwen3-235B-A22B", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("zai-org/GLM-4.6", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("openai/gpt-oss-120b", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("google/gemma-4-31B-it", 1, token)
+
+    # Models that SHOULD NOT have the flag
+    assert "--trust-remote-code" not in get_vllm_args("facebook/opt-125m", 1, token)
+    assert "--trust-remote-code" not in get_vllm_args("meta-llama/Llama-4-Maverick-17B-128E-Instruct", 1, token)
+    assert "--trust-remote-code" not in get_vllm_args("tiiuae/Falcon3-10B-Instruct", 1, token)


### PR DESCRIPTION
This change adds support for benchmarking seven new public models (Kimi K2.5, Falcon 3, Meta-Llama-4, Qwen3-235B-A22B, GLM 4.6, gpt-oss-120B, and Qwen3-235B-Instruct-2507). 

Key modifications:
1. **Model Metadata:** Identified correct Hugging Face repository IDs and verified total parameter counts to ensure the automated resource provisioning (VRAM and disk space) in `launch.py` works correctly.
2. **Launch Logic:** Updated `launch.py` to automatically apply the `--trust-remote-code` flag for models with custom architectures or newer releases.
3. **Workflow & Docs:** Expanded the `vast_ai_benchmark.yml` inputs and the `GEMMA.md` test list.
4. **Reliability:** Refactored `launch.py` for better testability and added comprehensive unit tests in `tests/test_launch_logic.py`. The entire lifecycle was verified against a local mock server environment.

Fixes #124

---
*PR created automatically by Jules for task [4191926486261054080](https://jules.google.com/task/4191926486261054080) started by @chatelao*