### PR TITLE
Add DeepSeek-V4 models for coding and chat benchmarks

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -44,6 +44,8 @@ on:
         - 'mistralai/Mistral-Large-Instruct-2411'
         - 'Qwen/Qwen2.5-Coder-32B-Instruct'
         - 'deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct'
+        - 'deepseek-ai/DeepSeek-V4-Flash'
+        - 'deepseek-ai/DeepSeek-V4-Pro'
         - 'mistralai/Codestral-22B-v0.1'
         - 'moonshotai/Kimi-K2.5'
         - 'tiiuae/Falcon3-10B-Instruct'

--- a/MODELS_AND_TARGETS.md
+++ b/MODELS_AND_TARGETS.md
@@ -27,6 +27,8 @@ The recommendations are based on the following formulas used in `launch.py`:
 |  | `Qwen/Qwen3-235B-A22B` | 8x A100 (80GB) | 71 GB | 482 GB |
 |  | `Qwen/Qwen3-235B-A22B-Instruct-2507` | 8x A100 (80GB) | 71 GB | 482 GB |
 | **DeepSeek** | `deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct` | 4x RTX 4090 or 1x A100 | 20 GB (4x) / 44 GB (1x) | 44 GB |
+|  | `deepseek-ai/DeepSeek-V4-Flash` | 8x H200 | 83 GB | 580 GB |
+|  | `deepseek-ai/DeepSeek-V4-Pro` | Requires Multi-node | 412 GB | 3212 GB |
 | **Kimi** | `moonshotai/Kimi-K2.5` | Requires Multi-node | 287 GB | 2212 GB |
 | **Falcon** | `tiiuae/Falcon3-10B-Instruct` | 2x RTX 4090 or 1x A100 | 22 GB (2x) / 32 GB (1x) | 32 GB |
 | **Llama 4** | `meta-llama/Llama-4-Maverick-17B-128E-Instruct` | 8x H200 | 112 GB | 812 GB |

--- a/launch.py
+++ b/launch.py
@@ -23,6 +23,10 @@ def estimate_model_params(model_name):
         return 123.0
     if "deepseek-coder-v2-lite" in model_name_lower:
         return 16.0
+    if "deepseek-v4-flash" in model_name_lower:
+        return 284.0
+    if "deepseek-v4-pro" in model_name_lower:
+        return 1600.0
     if "kimi-k2.5" in model_name_lower:
         return 1100.0
     if "falcon3-10b" in model_name_lower:
@@ -63,7 +67,7 @@ def get_vllm_args(model, num_gpus, vllm_api_key):
 
     # Gemma 4 models require --trust-remote-code because the architecture is often newer than the transformers version in the template.
     # New model families also often use custom architectures or are newer than the transformers version in default templates.
-    models_trust_remote_code = ["gemma-4", "kimi", "qwen3", "glm-4", "gpt-oss"]
+    models_trust_remote_code = ["gemma-4", "kimi", "qwen3", "glm-4", "gpt-oss", "deepseek-v4"]
     if any(m in model.lower() for m in models_trust_remote_code):
         vllm_args += " --trust-remote-code"
 

--- a/tests/test_launch_logic.py
+++ b/tests/test_launch_logic.py
@@ -9,6 +9,8 @@ def test_estimate_model_params_new_models():
     assert estimate_model_params("zai-org/GLM-4.6") == 357.0
     assert estimate_model_params("openai/gpt-oss-120b") == 117.0
     assert estimate_model_params("Qwen/Qwen3-235B-A22B-Instruct-2507") == 235.0
+    assert estimate_model_params("deepseek-ai/DeepSeek-V4-Flash") == 284.0
+    assert estimate_model_params("deepseek-ai/DeepSeek-V4-Pro") == 1600.0
 
 def test_estimate_model_params_existing_models():
     assert estimate_model_params("facebook/opt-125m") == 0.125
@@ -25,6 +27,8 @@ def test_get_vllm_args_trust_remote_code():
     assert "--trust-remote-code" in get_vllm_args("zai-org/GLM-4.6", 1, token)
     assert "--trust-remote-code" in get_vllm_args("openai/gpt-oss-120b", 1, token)
     assert "--trust-remote-code" in get_vllm_args("google/gemma-4-31B-it", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("deepseek-ai/DeepSeek-V4-Flash", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("deepseek-ai/DeepSeek-V4-Pro", 1, token)
 
     # Models that SHOULD NOT have the flag
     assert "--trust-remote-code" not in get_vllm_args("facebook/opt-125m", 1, token)


### PR DESCRIPTION
This PR adds support for the new DeepSeek-V4 series (Flash and Pro) to the Vast.ai benchmarking framework. These models are highly optimized for both chat and coding tasks and represent the latest frontier in open-source million-token context intelligence.

Key changes:
- **launch.py**: Integrated parameter estimation (284B for Flash, 1.6T for Pro) and ensured the `--trust-remote-code` flag is correctly applied to these models.
- **MODELS_AND_TARGETS.md**: Provided hardware guidance, recommending 8x H200 for Flash and multi-node setups for Pro.
- **GitHub Workflow**: Enabled these models for automated benchmarking via manual dispatch.
- **Tests**: Expanded the test suite to verify the logic for these high-parameter MoE models.

Fixes #149

---
*PR created automatically by Jules for task [13859389933420628224](https://jules.google.com/task/13859389933420628224) started by @chatelao*