### PR TITLE
Upgrade Model Ecosystem to SOTA May 2026

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -56,6 +56,17 @@ on:
         - 'zai-org/GLM-4.6'
         - 'openai/gpt-oss-120b'
         - 'Qwen/Qwen3-235B-A22B-Instruct-2507'
+        - 'deepseek-ai/DeepSeek-V4-Flash'
+        - 'deepseek-ai/DeepSeek-V4-Pro'
+        - 'deepseek-ai/DeepSeek-V3.2'
+        - 'deepseek-ai/DeepSeek-R1'
+        - 'meta-llama/Llama-4-Scout'
+        - 'mistralai/Codestral-2'
+        - 'Qwen/Qwen-3.6-35B-A3B'
+        - 'zai-org/GLM-5.1'
+        - 'moonshotai/Kimi-K2.6'
+        - 'step-ai/Step-3.5-Flash'
+        - 'ibm-granite/granite-4.0-8b-instruct'
       concurrency_levels:
         description: 'Space-separated concurrency levels'
         required: true

--- a/MODELS_AND_TARGETS.md
+++ b/MODELS_AND_TARGETS.md
@@ -37,6 +37,17 @@ The recommendations are based on the following formulas used in `launch.py`:
 | **GLM** | `zai-org/GLM-4.6` | 8x H200 | 101 GB | 726 GB |
 | **GPT-OSS** | `openai/gpt-oss-120b` | 4x A100 (80GB) / H100 | 70 GB | 246 GB |
 | **Small/Test** | `facebook/opt-125m` | 1x RTX 4090 / 3090 | 12 GB | 12 GB |
+| **SOTA 2026** | `deepseek-ai/DeepSeek-V4-Flash` | 8x H200 | 83 GB | 580 GB |
+|  | `deepseek-ai/DeepSeek-V4-Pro` | Requires Multi-node | 412 GB | 3212 GB |
+|  | `deepseek-ai/DeepSeek-V3.2` | 8x B200 (192GB) | 180 GB | 1354 GB |
+|  | `deepseek-ai/DeepSeek-R1` | 8x B200 (192GB) | 180 GB | 1354 GB |
+|  | `meta-llama/Llama-4-Scout` | 8x H200 | 112 GB | 812 GB |
+|  | `mistralai/Codestral-2` | 1x A100 (80GB) | 56 GB | 56 GB |
+|  | `Qwen/Qwen-3.6-35B-A3B` | 2x A100 (80GB) | 47 GB | 82 GB |
+|  | `zai-org/GLM-5.1` | Requires Multi-node | 201 GB | 1520 GB |
+|  | `moonshotai/Kimi-K2.6` | Requires Multi-node | 262 GB | 2012 GB |
+|  | `step-ai/Step-3.5-Flash` | 1x A100 (80GB) | 52 GB | 52 GB |
+|  | `ibm-granite/granite-4.0-8b-instruct` | 2x RTX 4090 or 1x A100 | 20 GB (2x) / 28 GB (1x) | 28 GB |
 
 *\*Gemma 4 refers to specific experimental model variants supported in this benchmark suite.*
 

--- a/launch.py
+++ b/launch.py
@@ -45,6 +45,28 @@ def estimate_model_params(model_name):
         return 357.0
     if "gpt-oss-120b" in model_name_lower:
         return 117.0
+    if "deepseek-v4-flash" in model_name_lower:
+        return 284.0
+    if "deepseek-v4-pro" in model_name_lower:
+        return 1600.0
+    if "deepseek-v3.2" in model_name_lower:
+        return 671.0
+    if "deepseek-r1" in model_name_lower:
+        return 671.0
+    if "llama-4-scout" in model_name_lower:
+        return 400.0
+    if "codestral-2" in model_name_lower:
+        return 22.0
+    if "qwen-3.6-35b-a3b" in model_name_lower:
+        return 35.0
+    if "glm-5.1" in model_name_lower:
+        return 754.0
+    if "kimi-k2.6" in model_name_lower:
+        return 1000.0
+    if "step-3.5-flash" in model_name_lower:
+        return 20.0
+    if "granite-4.0" in model_name_lower:
+        return 8.0
 
     # Regex to find patterns like 7b, 125m, 0.5b
     match = re.search(r"(\d+(?:\.\d+)?)\s*([mb])", model_name_lower)
@@ -73,7 +95,7 @@ def get_vllm_args(model, num_gpus, vllm_api_key):
 
     # Gemma 4 models require --trust-remote-code because the architecture is often newer than the transformers version in the template.
     # New model families also often use custom architectures or are newer than the transformers version in default templates.
-    models_trust_remote_code = ["gemma-4", "kimi", "qwen3", "glm-4", "gpt-oss", "mistral", "ministral", "devstral"]
+    models_trust_remote_code = ["gemma-4", "kimi", "qwen", "glm", "gpt-oss", "mistral", "ministral", "devstral", "deepseek", "step", "granite", "codestral"]
     if any(m in model.lower() for m in models_trust_remote_code):
         vllm_args += " --trust-remote-code"
 

--- a/tests/test_launch_logic.py
+++ b/tests/test_launch_logic.py
@@ -9,6 +9,17 @@ def test_estimate_model_params_new_models():
     assert estimate_model_params("zai-org/GLM-4.6") == 357.0
     assert estimate_model_params("openai/gpt-oss-120b") == 117.0
     assert estimate_model_params("Qwen/Qwen3-235B-A22B-Instruct-2507") == 235.0
+    assert estimate_model_params("deepseek-ai/DeepSeek-V4-Flash") == 284.0
+    assert estimate_model_params("deepseek-ai/DeepSeek-V4-Pro") == 1600.0
+    assert estimate_model_params("deepseek-ai/DeepSeek-V3.2") == 671.0
+    assert estimate_model_params("deepseek-ai/DeepSeek-R1") == 671.0
+    assert estimate_model_params("meta-llama/Llama-4-Scout") == 400.0
+    assert estimate_model_params("mistralai/Codestral-2") == 22.0
+    assert estimate_model_params("Qwen/Qwen-3.6-35B-A3B") == 35.0
+    assert estimate_model_params("zai-org/GLM-5.1") == 754.0
+    assert estimate_model_params("moonshotai/Kimi-K2.6") == 1000.0
+    assert estimate_model_params("step-ai/Step-3.5-Flash") == 20.0
+    assert estimate_model_params("ibm-granite/granite-4.0-8b-instruct") == 8.0
 
 def test_estimate_model_params_existing_models():
     assert estimate_model_params("facebook/opt-125m") == 0.125
@@ -34,6 +45,12 @@ def test_get_vllm_args_trust_remote_code():
     assert "--trust-remote-code" in get_vllm_args("mistralai/Mistral-Small-4-119B-2603", 1, token)
     assert "--trust-remote-code" in get_vllm_args("mistralai/Ministral-3-3B-Instruct-2512", 1, token)
     assert "--trust-remote-code" in get_vllm_args("mistralai/Devstral-2-123B-Instruct-2512", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("deepseek-ai/DeepSeek-V4-Flash", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("zai-org/GLM-5.1", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("step-ai/Step-3.5-Flash", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("ibm-granite/granite-4.0-8b-instruct", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("mistralai/Codestral-2", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("Qwen/Qwen-3.6-35B-A3B", 1, token)
 
     # Models that SHOULD NOT have the flag
     assert "--trust-remote-code" not in get_vllm_args("facebook/opt-125m", 1, token)


### PR DESCRIPTION
This submission upgrades the benchmarking framework to include the latest state-of-the-art models as of May 2026. 

Key changes:
1. **Model Parameter Estimation**: Added explicit parameter counts for the new DeepSeek, Llama, Mistral, Qwen, GLM, Kimi, Step, and Granite variants in `launch.py`.
2. **vLLM Configuration**: Updated the `--trust-remote-code` whitelist to support the new model architectures.
3. **Hardware Recommendations**: Updated `MODELS_AND_TARGETS.md` with calculated VRAM and disk requirements for each new model, along with recommended GPU targets (e.g., H200, B200, Multi-node).
4. **CI/CD Integration**: Added the new models to the `workflow_dispatch` inputs in `.github/workflows/vast_ai_benchmark.yml`.
5. **Validation**: Implemented and verified new test cases in `tests/test_launch_logic.py` covering all added models.

Fixes #155

---
*PR created automatically by Jules for task [7269663214675235647](https://jules.google.com/task/7269663214675235647) started by @chatelao*