### PR TITLE
Expand default concurrency levels

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -72,7 +72,7 @@ on:
       concurrency_levels:
         description: 'Space-separated concurrency levels'
         required: true
-        default: '1 4 16'
+        default: '1 4 16 64 256 1024 4096'
       requests_per_level:
         description: 'Number of requests per concurrency level'
         required: true

--- a/benchmark.py
+++ b/benchmark.py
@@ -196,7 +196,7 @@ async def main():
     parser.add_argument("--gpu", default="RTX_4090")
     parser.add_argument("--num-gpus", type=int, default=1)
     parser.add_argument("--url", help="Override API URL")
-    parser.add_argument("--concurrency-levels", type=int, nargs="+", default=[1, 4, 16])
+    parser.add_argument("--concurrency-levels", type=int, nargs="+", default=[1, 4, 16, 64, 256, 1024, 4096])
     parser.add_argument("--requests-per-level", type=int, default=10)
     parser.add_argument("--benchmark-type", choices=["llmperf", "vllm"], default="llmperf",
                         help="Benchmark engine to use (default: llmperf)")


### PR DESCRIPTION
The default concurrency levels for the Vast.ai benchmark have been expanded.
The previous defaults were `1 4 16`.
Four additional levels have been added: `64 256 1024 4096`.
These changes were applied to:
- `.github/workflows/vast_ai_benchmark.yml`
- `benchmark.py`

All existing tests pass, and the changes have been verified.

Fixes #161

---
*PR created automatically by Jules for task [5969838098988545466](https://jules.google.com/task/5969838098988545466) started by @chatelao*