### PR TITLE
Add Magistral-Small-2509 and Xortron models

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -48,6 +48,8 @@ on:
         - 'mistralai/Ministral-3-14B-Instruct-2512'
         - 'mistralai/Devstral-2-123B-Instruct-2512'
         - 'mistralai/Codestral-2'
+        - 'mistralai/Magistral-Small-2509'
+        - 'darkc0de/XortronCriminalComputingConfig'
         - 'Qwen/Qwen2.5-Coder-32B-Instruct'
         - 'deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct'
         - 'moonshotai/Kimi-K2.5'

--- a/MODELS_AND_TARGETS.md
+++ b/MODELS_AND_TARGETS.md
@@ -27,6 +27,7 @@ The recommendations are based on the following formulas used in `launch.py`:
 |  | `mistralai/Codestral-22B-v0.1` | 4x RTX 4090 or 1x A100 | 23 GB / 56 GB | 56 GB | Dense | - | High | High | |
 |  | `mistralai/Codestral-v0.2` | 4x RTX 4090 or 1x A100 | 23 GB / 56 GB | 56 GB | Dense | - | High | High | |
 |  | `mistralai/Codestral-2` | 4x RTX 4090 or 1x A100 | 23 GB / 56 GB | 56 GB | Dense | - | High++| High++| Standard Instruct & FIM |
+|  | `mistralai/Magistral-Small-2509` | 4x RTX 4090 or 1x A100 | 24 GB / 60 GB | 60 GB | Dense | - | High | High | Pixtral-based vision |
 | **Qwen** | `Qwen/Qwen2.5-Coder-32B-Instruct` | 1x A100 (80GB) | 76 GB | 76 GB | Dense | - | High++| High++| |
 |  | `Qwen/Qwen3-235B-A22B` | 8x A100 (80GB) | 71 GB | 482 GB | MoE | 64 | High | High | |
 |  | `Qwen/Qwen3-235B-A22B-Instruct-2507` | 8x A100 (80GB) | 71 GB | 482 GB | MoE | 64 | High | High | |
@@ -47,6 +48,7 @@ The recommendations are based on the following formulas used in `launch.py`:
 | **Small/Test** | `facebook/opt-125m` | 1x RTX 4090 / 3090 | 12 GB | 12 GB | Dense | - | N/A | N/A | |
 |  | `step-ai/Step-3.5-Flash` | 1x A100 (80GB) | 52 GB | 52 GB | Dense | - | Mid | Mid | MTP-3 |
 |  | `ibm/Granite-4.0-8B-Instruct` | 2x RTX 4090 or 1x A100 | 20 GB / 28 GB | 28 GB | Hybrid| - | Mid | Mid | Hybrid Mamba2 |
+| **Xortron** | `darkc0de/XortronCriminalComputingConfig` | 4x RTX 4090 or 1x A100 | 24 GB / 60 GB | 60 GB | Dense | - | High | High | Uncensored, Mistral-based |
 
 *\*Gemma 4 refers to specific experimental model variants supported in this benchmark suite.*
 

--- a/launch.py
+++ b/launch.py
@@ -52,7 +52,9 @@ def estimate_model_params(model_name):
         "codestral": 22.0,           # Estimate based on v0.1
         "codestral-2": 22.0,
         "step-3.5-flash": 20.0,      # Verified count
-        "granite-4.0": 8.0           # Estimate for Granite-class
+        "granite-4.0": 8.0,          # Estimate for Granite-class
+        "magistral-small": 24.0,     # Verified count (24B)
+        "xortron": 24.0              # Verified count (24B)
     }
 
     for key, value in mappings.items():
@@ -78,7 +80,8 @@ def get_vllm_args(model, num_gpus, vllm_api_key):
     # New model families also often use custom architectures or are newer than the transformers version in default templates.
     models_trust_remote_code = [
         "gemma-4", "kimi", "qwen3", "qwen-3.6", "glm-4", "glm-5", "gpt-oss",
-        "deepseek", "step", "granite", "mistral", "ministral", "devstral", "llama-4"
+        "deepseek", "step", "granite", "mistral", "ministral", "devstral", "llama-4",
+        "magistral", "xortron"
     ]
     if any(m in model.lower() for m in models_trust_remote_code):
         vllm_args += " --trust-remote-code"

--- a/models_benchmark.txt
+++ b/models_benchmark.txt
@@ -2,6 +2,7 @@ Qwen/Qwen-3.6-35B-A3B
 Qwen/Qwen2.5-Coder-32B-Instruct
 Qwen/Qwen3-235B-A22B
 Qwen/Qwen3-235B-A22B-Instruct-2507
+darkc0de/XortronCriminalComputingConfig
 deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
 deepseek-ai/DeepSeek-R1
 deepseek-ai/DeepSeek-V3.2
@@ -20,6 +21,7 @@ mistralai/Codestral-2
 mistralai/Codestral-v0.2
 mistralai/Devstral-2-123B-Instruct
 mistralai/Devstral-2-123B-Instruct-2512
+mistralai/Magistral-Small-2509
 mistralai/Ministral-3-14B-Instruct-2512
 mistralai/Ministral-3-3B-Instruct-2512
 mistralai/Ministral-3-8B-Instruct-2512

--- a/models_verify.txt
+++ b/models_verify.txt
@@ -2,6 +2,7 @@ Qwen/Qwen-3.6-35B-A3B
 Qwen/Qwen2.5-Coder-32B-Instruct
 Qwen/Qwen3-235B-A22B
 Qwen/Qwen3-235B-A22B-Instruct-2507
+darkc0de/XortronCriminalComputingConfig
 deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct
 deepseek-ai/DeepSeek-R1
 deepseek-ai/DeepSeek-V3.2
@@ -20,6 +21,7 @@ mistralai/Codestral-2
 mistralai/Codestral-v0.2
 mistralai/Devstral-2-123B-Instruct
 mistralai/Devstral-2-123B-Instruct-2512
+mistralai/Magistral-Small-2509
 mistralai/Ministral-3-14B-Instruct-2512
 mistralai/Ministral-3-3B-Instruct-2512
 mistralai/Ministral-3-8B-Instruct-2512


### PR DESCRIPTION
I've integrated the `mistralai/Magistral-Small-2509` and `darkc0de/XortronCriminalComputingConfig` models into the benchmark suite.

Key updates:
1.  **Resource Estimation:** Both models were identified as ~24B parameters. I've updated `launch.py` to correctly estimate their VRAM and Disk requirements.
2.  **Compatibility:** Added both models to the `--trust-remote-code` whitelist in `launch.py` to ensure they load correctly in vLLM.
3.  **Documentation:** Added hardware recommendations to `MODELS_AND_TARGETS.md`. For these 24B models, a 4x RTX 4090 or 1x A100 (80GB) setup is recommended.
4.  **Automation:** Added the models to the GitHub Action workflow inputs and the tracking files (`models_benchmark.txt`, `models_verify.txt`).

Verified the logic using `pytest` and a custom verification script (which was cleaned up after use).

Fixes #160

---
*PR created automatically by Jules for task [3126639893873326280](https://jules.google.com/task/3126639893873326280) started by @chatelao*