### PR TITLE
Optimize Ray actor management and suppress initialization warnings

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -133,7 +133,8 @@ class LLMPerfTester:
                 ignore_reinit_error=True,
                 runtime_env={"env_vars": {
                     "OPENAI_API_BASE": self.base_url,
-                    "OPENAI_API_KEY": self.api_key or "vllm-benchmark-token"
+                    "OPENAI_API_KEY": self.api_key or "vllm-benchmark-token",
+                    "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0"
                 }}
             )
 
@@ -142,8 +143,12 @@ class LLMPerfTester:
         from llmperf.models import RequestConfig
         from llmperf import common_metrics
 
-        # Create a pool of actors to handle requests
-        clients = [OpenAIChatCompletionsClient.remote() for _ in range(concurrency)]
+        # Create a pool of actors to handle requests.
+        # Cap at 32 actors to avoid "too many worker processes" and Ray resource exhaustion.
+        # Use num_cpus=0 as these actors are primarily waiting for I/O.
+        # Set max_concurrency to allow each actor to handle multiple concurrent requests.
+        num_actors = min(concurrency, 32)
+        clients = [OpenAIChatCompletionsClient.options(num_cpus=0, max_concurrency=1000).remote() for _ in range(num_actors)]
         client_pool = itertools.cycle(clients)
         semaphore = asyncio.Semaphore(concurrency)
 


### PR DESCRIPTION
This change fixes the `(raylet) WARNING: 16 PYTHON worker processes` and subsequent GCS server crash encountered when running benchmarks at high concurrency (e.g., 256, 1024). It also suppresses a `FutureWarning` about accelerator environment variable overrides.

Key improvements:
1. **Actor Capping**: Limited the number of Ray actors created to a maximum of 32 (or the requested concurrency, if smaller). This prevents the system from being overwhelmed by thousands of worker processes at high concurrency levels (up to 4096).
2. **High Throughput Support**: Enabled `max_concurrency=1000` on the Ray actors. This allows the small pool of 32 actors to handle many concurrent requests simultaneously using Ray's internal async/threaded execution, preserving the validity of high-concurrency benchmark results.
3. **Resource Efficiency**: Explicitly set `num_cpus=0` for the actors since they are primarily I/O-bound (waiting for LLM API responses), ensuring they don't consume unnecessary Ray CPU slots.
4. **Warning Suppression**: Set `RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO="0"` in the Ray `runtime_env` to silence the persistent `FutureWarning` during initialization.

Verified by running existing launch logic tests and manually reviewing the modified code logic.

Fixes #170

---
*PR created automatically by Jules for task [7162760518934093684](https://jules.google.com/task/7162760518934093684) started by @chatelao*