### PR TITLE
Add remote execution option to Vast.ai benchmark

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -102,6 +102,11 @@ on:
         options:
         - 'llmperf'
         - 'vllm'
+      run_remote:
+        description: 'Run benchmark remote on the Vast.ai VM'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   benchmark:
@@ -140,14 +145,21 @@ jobs:
         python poll.py
 
     - name: Benchmark
+      env:
+        VAST_AI_API_KEY: ${{ secrets.VAST_AI_API_KEY }}
       run: |
+        REMOTE_FLAG=""
+        if [ "${{ github.event.inputs.run_remote }}" = "true" ]; then
+          REMOTE_FLAG="--remote"
+        fi
         python benchmark.py \
           --gpu "${{ github.event.inputs.gpu }}" \
           --num-gpus "${{ github.event.inputs.num_gpus }}" \
           --model "${{ github.event.inputs.model }}" \
           --concurrency-levels ${{ github.event.inputs.concurrency_levels }} \
           --requests-per-level ${{ github.event.inputs.requests_per_level }} \
-          --benchmark-type "${{ github.event.inputs.benchmark_type }}"
+          --benchmark-type "${{ github.event.inputs.benchmark_type }}" \
+          $REMOTE_FLAG
 
     - name: Teardown
       if: always()

--- a/benchmark.py
+++ b/benchmark.py
@@ -9,6 +9,7 @@ import sys
 import datetime
 import random
 import itertools
+import shlex
 
 PROMPTS = [
     "Explain quantum physics in one sentence.",
@@ -190,6 +191,114 @@ class LLMPerfTester:
             "total_tps": sum([r[common_metrics.NUM_OUTPUT_TOKENS] for r in valid]) / duration_run
         }
 
+async def run_benchmark(tester, args):
+    all_results = []
+    log(f"Starting benchmark for {args.model}...")
+    for c in args.concurrency_levels:
+        log(f"  Concurrency {c}...")
+        res = await tester.run(c, args.requests_per_level)
+        if res:
+            all_results.append(res)
+            log(f"    TPS: {res['total_tps']:.2f}")
+    return all_results
+
+def report_results(all_results, args):
+    if not all_results:
+        log("::error::No results collected. Exiting with failure.")
+        sys.exit(1)
+
+    summary_file = os.getenv("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write(f"## Results: {args.model} on {args.num_gpus}x {args.gpu}\n")
+            f.write("| C | Success Rate | Avg TTFT | Avg TPS | Total TPS |\n|---|---|---|---|---|\n")
+            for r in all_results:
+                f.write(f"| {r['concurrency']} | {r['success_rate']*100:.1f}% | {r['avg_ttft']:.3f} | {r['avg_tps']:.2f} | {r['total_tps']:.2f} |\n")
+        log(f"Summary written to {summary_file}")
+
+    gpu_str = f"{args.num_gpus}x_{args.gpu.replace(' ', '_')}"
+    timestamp = int(time.time())
+    output_file = os.path.join(args.output_dir, f"benchmark_{gpu_str}_{timestamp}.json")
+    results_json = os.path.join(args.output_dir, "results.json")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    with open(output_file, "w") as f:
+        json.dump(all_results, f, indent=2)
+    log(f"Results written to {output_file}")
+    with open(results_json, "w") as f:
+        json.dump(all_results, f, indent=2)
+    log(f"Results written to {results_json}")
+
+async def run_remote(args):
+    from vastai.sdk import VastAI
+
+    if not os.path.exists(".vast_instance_id"):
+        log("::error::.vast_instance_id not found")
+        sys.exit(1)
+
+    with open(".vast_instance_id", "r") as f:
+        instance_id = f.read().strip()
+
+    api_key = os.getenv("VAST_AI_API_KEY")
+    if not api_key:
+        log("::error::VAST_AI_API_KEY not set")
+        sys.exit(1)
+
+    sdk = VastAI(api_key=api_key)
+    log(f"Running remote benchmark on instance {instance_id}...")
+
+    # 1. Copy benchmark script to instance
+    log("Copying benchmark.py to instance...")
+    sdk.copy("local:benchmark.py", f"{instance_id}:benchmark.py")
+
+    # 2. Prepare remote command
+    # Filter out --remote and use localhost URL
+    remote_args = []
+    skip_next = False
+    for i, arg in enumerate(sys.argv[1:]):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--remote":
+            continue
+        if arg == "--url":
+            skip_next = True
+            continue
+        remote_args.append(arg)
+
+    remote_args.extend(["--url", "http://localhost:8000"])
+    remote_args.extend(["--output-dir", "results_remote"])
+
+    quoted_args = [shlex.quote(a) for a in remote_args]
+    cmd = (
+        "pip install aiohttp requests tqdm transformers numpy ray && "
+        "pip install git+https://github.com/ray-project/llmperf.git && "
+        "mkdir -p results_remote && "
+        f"python3 benchmark.py {' '.join(quoted_args)}"
+    )
+
+    # 3. Execute remote command
+    log(f"Executing remote command: {cmd}")
+    res = sdk.execute(int(instance_id), cmd)
+    # The result of execute is a dict. Depending on the SDK version it might contain more info.
+    # We log it for debugging and check if we got a response.
+    log(f"Remote execution finished. Result: {str(res)[:200]}")
+
+    # 4. Download results
+    log("Downloading results from instance...")
+    # Download the whole results directory
+    sdk.copy(f"{instance_id}:results_remote/", "local:.")
+
+    # After copying, the files from results_remote/ should be in the local current dir
+    # because of how vastai copy works (it's like scp -r).
+    # Wait, scp -r remote:dir/ local:target/ copies contents of dir into target.
+
+    local_results = "results.json"
+    if os.path.exists(local_results):
+        with open(local_results, "r") as f:
+            return json.load(f)
+    return None
+
 async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True)
@@ -200,6 +309,8 @@ async def main():
     parser.add_argument("--requests-per-level", type=int, default=10)
     parser.add_argument("--benchmark-type", choices=["llmperf", "vllm"], default="llmperf",
                         help="Benchmark engine to use (default: llmperf)")
+    parser.add_argument("--remote", action="store_true", help="Run benchmark remote on the Vast.ai instance")
+    parser.add_argument("--output-dir", default=".", help="Directory to save result files")
     args = parser.parse_args()
 
     api_url = args.url
@@ -212,41 +323,16 @@ async def main():
 
     vllm_api_key = os.getenv("VLLM_API_KEY_OVERRIDE", "vllm-benchmark-token")
 
-    if args.benchmark_type == "llmperf":
-        tester = LLMPerfTester(api_url, args.model, vllm_api_key)
+    if args.remote:
+        all_results = await run_remote(args)
     else:
-        tester = LoadTester(api_url, args.model, vllm_api_key)
-    all_results = []
+        if args.benchmark_type == "llmperf":
+            tester = LLMPerfTester(api_url, args.model, vllm_api_key)
+        else:
+            tester = LoadTester(api_url, args.model, vllm_api_key)
+        all_results = await run_benchmark(tester, args)
 
-    log(f"Starting benchmark for {args.model}...")
-    for c in args.concurrency_levels:
-        log(f"  Concurrency {c}...")
-        res = await tester.run(c, args.requests_per_level)
-        if res:
-            all_results.append(res)
-            log(f"    TPS: {res['total_tps']:.2f}")
-
-    if all_results:
-        summary_file = os.getenv("GITHUB_STEP_SUMMARY")
-        if summary_file:
-            with open(summary_file, "a") as f:
-                f.write(f"## Results: {args.model} on {args.num_gpus}x {args.gpu}\n")
-                f.write("| C | Success Rate | Avg TTFT | Avg TPS | Total TPS |\n|---|---|---|---|---|\n")
-                for r in all_results:
-                    f.write(f"| {r['concurrency']} | {r['success_rate']*100:.1f}% | {r['avg_ttft']:.3f} | {r['avg_tps']:.2f} | {r['total_tps']:.2f} |\n")
-            log(f"Summary written to {summary_file}")
-
-        gpu_str = f"{args.num_gpus}x_{args.gpu.replace(' ', '_')}"
-        output_file = f"benchmark_{gpu_str}_{int(time.time())}.json"
-        with open(output_file, "w") as f:
-            json.dump(all_results, f, indent=2)
-        log(f"Results written to {output_file}")
-        with open("results.json", "w") as f:
-            json.dump(all_results, f, indent=2)
-        log(f"Results written to results.json")
-    else:
-        log("::error::No results collected. Exiting with failure.")
-        sys.exit(1)
+    report_results(all_results, args)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_remote_logic.py
+++ b/tests/test_remote_logic.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import os
+import sys
+import json
+import asyncio
+
+# Add the root directory to sys.path to import benchmark
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import benchmark
+
+class TestRemoteLogic(unittest.IsolatedAsyncioTestCase):
+    @patch("benchmark.os.getenv")
+    @patch("benchmark.os.path.exists")
+    @patch("benchmark.open")
+    async def test_run_remote_logic(self, mock_file, mock_exists, mock_getenv):
+        # Configure mocks
+        mock_getenv.side_effect = lambda k, default=None: "mock-api-key" if k == "VAST_AI_API_KEY" else default
+        mock_exists.side_effect = lambda path: True if path in [".vast_instance_id", "results.json"] else False
+
+        # Mock file reads: first for .vast_instance_id, second for results.json
+        mock_results = [{"concurrency": 1, "total_tps": 10.0}]
+        mock_file.side_effect = [
+            mock_open(read_data="2001").return_value,
+            mock_open(read_data=json.dumps(mock_results)).return_value
+        ]
+
+        mock_sdk = MagicMock()
+
+        # Patch the local import of VastAI inside run_remote by patching sys.modules or just the import
+        # Since it's imported inside the function, we can patch the module where it's imported from.
+        with patch("vastai.sdk.VastAI", return_value=mock_sdk):
+            args = MagicMock()
+            args.remote = True
+            args.model = "facebook/opt-125m"
+            args.gpu = "RTX 4090"
+            args.concurrency_levels = [1]
+            args.requests_per_level = 1
+
+            # sys.argv is used inside run_remote
+            with patch("sys.argv", ["benchmark.py", "--model", "facebook/opt-125m", "--gpu", "RTX 4090", "--remote"]):
+                result = await benchmark.run_remote(args)
+
+            # 1. Verify file copy to remote
+            mock_sdk.copy.assert_any_call("local:benchmark.py", "2001:benchmark.py")
+
+            # 2. Verify command execution and QUOTING
+            args_call = mock_sdk.execute.call_args[0]
+            self.assertEqual(args_call[0], 2001)
+            cmd = args_call[1]
+            self.assertIn("python3 benchmark.py", cmd)
+            self.assertIn("--model facebook/opt-125m", cmd)
+            self.assertIn("--gpu 'RTX 4090'", cmd)
+            self.assertNotIn("--remote", cmd)
+            self.assertIn("--url http://localhost:8000", cmd)
+            self.assertIn("--output-dir results_remote", cmd)
+
+            # 3. Verify download
+            mock_sdk.copy.assert_any_call("2001:results_remote/", "local:.")
+
+            # 4. Verify return value
+            self.assertEqual(result, mock_results)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces the ability to execute the LLM benchmark remotely on the rented Vast.ai instance instead of the GitHub runner. This minimizes network latency and maximizes bandwidth between the benchmark client and the vLLM server.

Key changes:
- `benchmark.py`: Added `--remote` and `--output-dir` arguments. Implemented `run_remote` orchestration using the `vastai` Python SDK.
- `benchmark.py`: Refactored core logic into reusable functions for benchmarking and reporting.
- Workflow: Added a boolean `run_remote` input to the `Vast.ai LLM Benchmark` workflow.
- Tests: Added unit tests for the remote orchestration logic, ensuring correct command construction and argument quoting.

Local execution remains the default, ensuring backward compatibility and stability for existing workflows.

Fixes #172

---
*PR created automatically by Jules for task [7483552185466521644](https://jules.google.com/task/7483552185466521644) started by @chatelao*