### PR TITLE
Add Phi-4 model support

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -64,6 +64,7 @@ on:
         - 'deepseek-ai/DeepSeek-V3.2'
         - 'deepseek-ai/DeepSeek-R1'
         - 'meta-llama/Llama-4-Scout-400B-Instruct'
+        - 'microsoft/phi-4'
         - 'mistralai/Devstral-2-123B-Instruct'
         - 'mistralai/Codestral-v0.2'
         - 'Qwen/Qwen-3.6-35B-A3B'

--- a/MODELS_AND_TARGETS.md
+++ b/MODELS_AND_TARGETS.md
@@ -40,6 +40,7 @@ The recommendations are based on the following formulas used in `launch.py`:
 | **Kimi** | `moonshotai/Kimi-K2.5` | Requires Multi-node | 287 GB | 2212 GB| MoE | 128 | High | High | |
 |  | `moonshotai/Kimi-K2.6` | Requires Multi-node | 262 GB | 2012 GB| MoE | 256 | High++| High++| Agentic Swarm |
 | **Falcon** | `tiiuae/Falcon3-10B-Instruct` | 2x RTX 4090 or 1x A100 | 22 GB / 32 GB | 32 GB | Dense | - | Mid | Mid | |
+| **Phi** | `microsoft/phi-4` | 2x RTX 4090 or 1x A100 | 19 GB / 35 GB | 42 GB | Dense | - | High | High | |
 | **Llama 4** | `meta-llama/Llama-4-Maverick-17B-128E-Instruct`| 8x H200 | 112 GB | 812 GB | MoE | 128 | High | High | |
 |  | `meta-llama/Llama-4-Scout-400B-Instruct` | 8x H200 | 112 GB | 812 GB | MoE | 256 | High++| High++| 10M Kontext, NoPE |
 | **GLM** | `zai-org/GLM-4.6` | 8x H200 | 101 GB | 726 GB | MoE | 64 | High | High | |

--- a/launch.py
+++ b/launch.py
@@ -56,6 +56,7 @@ def estimate_model_params(model_name):
         "granite-4.0": 8.0,          # Estimate for Granite-class
         "magistral-small": 24.0,     # Verified count (24B)
         "xortron": 24.0,             # Verified count (24B)
+        "phi-4": 14.7,               # Verified count (14.7B)
         "opt-125m": 0.125            # Specific mapping for tests
     }
 
@@ -83,7 +84,7 @@ def get_vllm_args(model, num_gpus, vllm_api_key):
     models_trust_remote_code = [
         "gemma-4", "kimi", "qwen3", "qwen-3.6", "glm-4", "glm-5", "gpt-oss",
         "deepseek", "step", "granite", "mistral", "ministral", "devstral", "llama-4",
-        "magistral", "xortron"
+        "magistral", "xortron", "phi"
     ]
     if any(m in model.lower() for m in models_trust_remote_code):
         vllm_args += " --trust-remote-code"

--- a/models_benchmark.txt
+++ b/models_benchmark.txt
@@ -17,6 +17,7 @@ google/gemma-4-E4B-it
 ibm/Granite-4.0-8B-Instruct
 meta-llama/Llama-4-Maverick-17B-128E-Instruct
 meta-llama/Llama-4-Scout-400B-Instruct
+microsoft/phi-4
 mistralai/Codestral-2
 mistralai/Codestral-v0.2
 mistralai/Devstral-2-123B-Instruct

--- a/models_verify.txt
+++ b/models_verify.txt
@@ -17,6 +17,7 @@ google/gemma-4-E4B-it
 ibm/Granite-4.0-8B-Instruct
 meta-llama/Llama-4-Maverick-17B-128E-Instruct
 meta-llama/Llama-4-Scout-400B-Instruct
+microsoft/phi-4
 mistralai/Codestral-2
 mistralai/Codestral-v0.2
 mistralai/Devstral-2-123B-Instruct

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -90,7 +90,7 @@ async def get_models(request):
 
             models_trust_remote_code = [
                 "gemma-4", "kimi", "qwen3", "qwen-3.6", "glm-4", "glm-5", "gpt-oss",
-                "deepseek", "step", "granite", "mistral", "ministral", "devstral", "llama-4"
+                "deepseek", "step", "granite", "mistral", "ministral", "devstral", "llama-4", "phi"
             ]
 
             if any(m in model for m in models_trust_remote_code) and "--trust-remote-code" not in args:

--- a/tests/test_launch_logic.py
+++ b/tests/test_launch_logic.py
@@ -24,6 +24,7 @@ def test_estimate_model_params_new_models():
     assert estimate_model_params("moonshotai/Kimi-K2.6") == 1000.0
     assert estimate_model_params("step-ai/Step-3.5-Flash") == 20.0
     assert estimate_model_params("ibm/Granite-4.0-8B-Instruct") == 8.0
+    assert estimate_model_params("microsoft/phi-4") == 14.7
 
 def test_estimate_model_params_existing_models():
     assert estimate_model_params("facebook/opt-125m") == 0.125
@@ -58,6 +59,7 @@ def test_get_vllm_args_trust_remote_code():
     assert "--trust-remote-code" in get_vllm_args("mistralai/Devstral-2-123B-Instruct-2512", 1, token)
     assert "--trust-remote-code" in get_vllm_args("mistralai/Mistral-Small-4-119B-2603", 1, token)
     assert "--trust-remote-code" in get_vllm_args("mistralai/Mistral-Medium-3.5-128B", 1, token)
+    assert "--trust-remote-code" in get_vllm_args("microsoft/phi-4", 1, token)
 
     # Models that SHOULD NOT have the flag
     assert "--trust-remote-code" not in get_vllm_args("facebook/opt-125m", 1, token)


### PR DESCRIPTION
This change integrates the Microsoft Phi-4 model into the Vast.ai benchmarking suite. 
- **Resource Estimation:** Phi-4 is mapped to 14.7B parameters, which correctly calculates VRAM and disk requirements (approx. 35GB VRAM for single GPU, 19GB for dual-GPU, 42GB disk).
- **Deployment:** The 'phi' model family is added to the list of models requiring the `--trust-remote-code` flag in vLLM.
- **Workflow & Metadata:** The model is now available as a choice in the GitHub Actions workflow and included in the automated tracking files (`models_benchmark.txt`, `models_verify.txt`).
- **Testing:** Unit tests in `tests/test_launch_logic.py` have been updated to verify the new logic, and the mock server has been updated to support the family.

Fixes #180

---
*PR created automatically by Jules for task [17402381078771734363](https://jules.google.com/task/17402381078771734363) started by @chatelao*