### PR TITLE
Optimize Ray resource allocation for high-concurrency benchmarks

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -132,6 +132,7 @@ class LLMPerfTester:
         if not ray.is_initialized():
             log(f"Initializing Ray with OPENAI_API_BASE={self.base_url}")
             ray.init(
+                num_cpus=MAX_RAY_ACTORS,
                 ignore_reinit_error=True,
                 runtime_env={"env_vars": {
                     "OPENAI_API_BASE": self.base_url,
@@ -147,7 +148,7 @@ class LLMPerfTester:
 
         # Create a pool of actors to handle requests
         num_actors = min(concurrency, MAX_RAY_ACTORS)
-        clients = [OpenAIChatCompletionsClient.remote() for _ in range(num_actors)]
+        clients = [OpenAIChatCompletionsClient.options(num_cpus=0).remote() for _ in range(num_actors)]
         client_pool = itertools.cycle(clients)
         semaphore = asyncio.Semaphore(concurrency)
 


### PR DESCRIPTION
This change optimizes how `llmperf` (via Ray) handles high-concurrency benchmarking on instances with a limited number of CPU cores.

The primary issue was that Ray's default scheduler tries to reserve 1 CPU per actor, and it warns when the number of concurrent worker startups exceeds a threshold proportional to the physical CPU count. By explicitly marking the actors as I/O-bound (`num_cpus=0`) and oversubscribing the Ray cluster's CPU capacity (`num_cpus=MAX_RAY_ACTORS` in `ray.init`), we allow the benchmark to reach high concurrency (up to 4096+ requests) without being throttled or triggering excessive warnings on common Vast.ai instances (which often have 4-8 vCPUs).

Verified using a reproduction script on a 4-CPU environment.

Fixes #188

---
*PR created automatically by Jules for task [15732113702908849475](https://jules.google.com/task/15732113702908849475) started by @chatelao*