### PR TITLE
Fix Node.js 20 deprecation in GitHub Actions

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -1,5 +1,8 @@
 name: Vast.ai LLM Benchmark
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/verify_all_models.yml
+++ b/.github/workflows/verify_all_models.yml
@@ -1,5 +1,8 @@
 name: Verify All Models Response
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/verify_scripts.yml
+++ b/.github/workflows/verify_scripts.yml
@@ -1,5 +1,8 @@
 name: Verify Scripting
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Resolved the Node.js 20 deprecation warning in GitHub Actions workflows by opting into Node.js 24 using the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable. This ensures the workflows continue to function correctly as GitHub transitions away from Node.js 20.

Fixes #206

---
*PR created automatically by Jules for task [4926703269591788274](https://jules.google.com/task/4926703269591788274) started by @chatelao*