### PR TITLE
Add prefix caching option to benchmark suite

### DIFF
--- a/.github/workflows/vast_ai_benchmark.yml
+++ b/.github/workflows/vast_ai_benchmark.yml
@@ -104,6 +104,11 @@ on:
         options:
         - 'llmperf'
         - 'vllm'
+      enable_prefix_caching:
+        description: 'Enable vLLM prefix caching'
+        required: true
+        default: false
+        type: boolean
       remote:
         description: 'Run benchmark remotely on Vast.ai instance'
         required: true
@@ -138,7 +143,8 @@ jobs:
           --num-gpus "${{ github.event.inputs.num_gpus }}" \
           --model "${{ github.event.inputs.model }}" \
           --template "${{ github.event.inputs.template }}" \
-          --disk "${{ github.event.inputs.disk }}"
+          --disk "${{ github.event.inputs.disk }}" \
+          ${{ github.event.inputs.enable_prefix_caching == 'true' && '--enable-prefix-caching' || '' }}
 
     - name: Poll
       env:
@@ -155,7 +161,8 @@ jobs:
           --model "${{ github.event.inputs.model }}" \
           --concurrency-levels ${{ github.event.inputs.concurrency_levels }} \
           --requests-per-level ${{ github.event.inputs.requests_per_level }} \
-          --benchmark-type "${{ github.event.inputs.benchmark_type }}"
+          --benchmark-type "${{ github.event.inputs.benchmark_type }}" \
+          ${{ github.event.inputs.enable_prefix_caching == 'true' && '--enable-prefix-caching' || '' }}
 
     - name: Benchmark (Remote)
       if: github.event.inputs.remote == 'true'
@@ -202,7 +209,8 @@ jobs:
             --url http://localhost:8000 \
             --concurrency-levels ${{ github.event.inputs.concurrency_levels }} \
             --requests-per-level ${{ github.event.inputs.requests_per_level }} \
-            --benchmark-type \"${{ github.event.inputs.benchmark_type }}\"
+            --benchmark-type \"${{ github.event.inputs.benchmark_type }}\" \
+            ${{ github.event.inputs.enable_prefix_caching == 'true' && '--enable-prefix-caching' || '' }}
         "
 
         scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -P $SSH_PORT root@$SSH_IP:/root/benchmark_*.json .

--- a/REMOTE_BENCHMARK.md
+++ b/REMOTE_BENCHMARK.md
@@ -48,11 +48,13 @@ python3 benchmark.py \
     --url http://localhost:8000 \
     --concurrency-levels 1 4 16 64 256 \
     --requests-per-level 256 \
-    --benchmark-type llmperf
+    --benchmark-type llmperf \
+    --enable-prefix-caching
 ```
 
 ### Key Options Explained
 
+*   **`--enable-prefix-caching`**: Toggle the vLLM prefix caching feature. This must be passed both to `launch.py` (to enable it on the server) and `benchmark.py` (to ensure it's correctly reported in the results).
 *   **`--gpu` & `--num-gpus`**: Crucial for result labeling. The output filenames and reports will use these to identify the hardware configuration.
 *   **`--requests-per-level`**: Follow the **Saturation Rule**. Ensure this is at least equal to your highest concurrency level (e.g., 256) to ensure the target concurrency is actually reached and maintained during the test.
 *   **`--benchmark-type llmperf`**: Recommended for high-concurrency testing. It uses Ray actors to distribute the load generation, preventing the benchmark script itself from becoming a CPU bottleneck.

--- a/benchmark.py
+++ b/benchmark.py
@@ -234,7 +234,7 @@ async def run_benchmark(tester, concurrency_levels, requests_per_level):
             log(f"    TPS: {res['total_tps']:.2f}")
     return all_results
 
-def report_results(all_results, model, gpu, num_gpus):
+def report_results(all_results, model, gpu, num_gpus, enable_prefix_caching=False):
     """Generate markdown summaries and JSON output files."""
     if not all_results:
         log("::error::No results collected to report.")
@@ -244,6 +244,7 @@ def report_results(all_results, model, gpu, num_gpus):
     if summary_file:
         with open(summary_file, "a") as f:
             f.write(f"## Results: {model} on {num_gpus}x {gpu}\n")
+            f.write(f"**Prefix Caching:** {'Enabled' if enable_prefix_caching else 'Disabled'}\n\n")
             f.write("| C | Success Rate | Avg TTFT | Avg TPS | Total TPS |\n|---|---|---|---|---|\n")
             for r in all_results:
                 f.write(f"| {r['concurrency']} | {r['success_rate']*100:.1f}% | {r['avg_ttft']:.3f} | {r['avg_tps']:.2f} | {r['total_tps']:.2f} |\n")
@@ -253,12 +254,20 @@ def report_results(all_results, model, gpu, num_gpus):
     timestamp = int(time.time())
     output_file = f"benchmark_{gpu_str}_{timestamp}.json"
 
+    output_data = {
+        "model": model,
+        "gpu": gpu,
+        "num_gpus": num_gpus,
+        "enable_prefix_caching": enable_prefix_caching,
+        "results": all_results
+    }
+
     with open(output_file, "w") as f:
-        json.dump(all_results, f, indent=2)
+        json.dump(output_data, f, indent=2)
     log(f"Results written to {output_file}")
 
     with open("results.json", "w") as f:
-        json.dump(all_results, f, indent=2)
+        json.dump(output_data, f, indent=2)
     log(f"Results written to results.json")
 
 async def main():
@@ -271,6 +280,7 @@ async def main():
     parser.add_argument("--requests-per-level", type=int, default=10)
     parser.add_argument("--benchmark-type", choices=["llmperf", "vllm"], default="llmperf",
                         help="Benchmark engine to use (default: llmperf)")
+    parser.add_argument("--enable-prefix-caching", action="store_true", help="Enable prefix caching (for reporting)")
     args = parser.parse_args()
 
     api_url = args.url
@@ -292,7 +302,7 @@ async def main():
     all_results = await run_benchmark(tester, args.concurrency_levels, args.requests_per_level)
 
     if all_results:
-        report_results(all_results, args.model, args.gpu, args.num_gpus)
+        report_results(all_results, args.model, args.gpu, args.num_gpus, enable_prefix_caching=args.enable_prefix_caching)
     else:
         log("::error::No results collected. Exiting with failure.")
         sys.exit(1)

--- a/launch.py
+++ b/launch.py
@@ -63,8 +63,11 @@ def estimate_model_params(model_name):
     # Default fallback
     return 7.0 # Default to 7B if unknown
 
-def get_vllm_args(model, num_gpus, vllm_api_key):
+def get_vllm_args(model, num_gpus, vllm_api_key, enable_prefix_caching=False):
     vllm_args = f"--dtype auto --enforce-eager --max-model-len 512 --block-size 16 --port 8000 --api-key {vllm_api_key}"
+
+    if enable_prefix_caching:
+        vllm_args += " --enable-prefix-caching"
 
     if num_gpus > 1:
         vllm_args += f" --tensor-parallel-size {num_gpus}"
@@ -93,6 +96,7 @@ def main():
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--template", "--template-hash", dest="template", type=str, default="38b2b68cf896e8582dff6f305a2041b1")
     parser.add_argument("--disk", type=float, default=10)
+    parser.add_argument("--enable-prefix-caching", action="store_true", help="Enable vLLM prefix caching")
     args = parser.parse_args()
 
     api_key = os.getenv("VAST_AI_API_KEY")
@@ -131,7 +135,7 @@ def main():
 
     hf_token = os.getenv("HF_TOKEN", "")
     vllm_api_key = os.getenv("VLLM_API_KEY_OVERRIDE", "vllm-benchmark-token")
-    vllm_args = get_vllm_args(args.model, args.num_gpus, vllm_api_key)
+    vllm_args = get_vllm_args(args.model, args.num_gpus, vllm_api_key, enable_prefix_caching=args.enable_prefix_caching)
 
     env_dict = {
         "VLLM_MODEL": args.model,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -62,7 +62,7 @@ def test_report_results(tmp_path):
         assert os.path.exists("results.json")
         with open("results.json", "r") as f:
             data = json.load(f)
-            assert data[0]["concurrency"] == 1
+            assert data["results"][0]["concurrency"] == 1
 
         # Cleanup
         if os.path.exists("results.json"):

--- a/tests/test_launch_logic.py
+++ b/tests/test_launch_logic.py
@@ -43,6 +43,10 @@ from launch import get_vllm_args
 
 def test_get_vllm_args_trust_remote_code():
     token = "test-token"
+    # Verify prefix caching flag
+    assert "--enable-prefix-caching" in get_vllm_args("opt-125m", 1, token, enable_prefix_caching=True)
+    assert "--enable-prefix-caching" not in get_vllm_args("opt-125m", 1, token, enable_prefix_caching=False)
+
     # Models that SHOULD have the flag
     assert "--trust-remote-code" in get_vllm_args("moonshotai/Kimi-K2.5", 1, token)
     assert "--trust-remote-code" in get_vllm_args("moonshotai/Kimi-K2.6", 1, token)


### PR DESCRIPTION
I have added the option to enable or disable prefix caching for the benchmark test runs. 

Specifically:
- **`launch.py`**: Added a new `--enable-prefix-caching` command-line argument. When enabled, it appends `--enable-prefix-caching` to the vLLM arguments passed to the server.
- **`benchmark.py`**: Added the same argument to the benchmark script. I updated the `report_results` function to include the prefix caching status in the Markdown summary and the JSON output. The JSON structure was also improved to include metadata like the model and GPU configuration alongside the results.
- **GitHub Workflow**: Updated the `vast_ai_benchmark.yml` workflow to include a boolean input for prefix caching, which is then passed to both the launch and benchmark steps (supporting both local and remote execution).
- **Documentation**: Added documentation for the new flag in `REMOTE_BENCHMARK.md`.
- **Tests**: Updated `tests/test_launch_logic.py` to verify the flag generation and updated `tests/test_benchmark.py` to align with the new JSON reporting structure. All tests passed successfully.

Fixes #212

---
*PR created automatically by Jules for task [17590118739278572578](https://jules.google.com/task/17590118739278572578) started by @chatelao*